### PR TITLE
Add balance sheet enhancements: IFRS cash flows and debt extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv
 *downloads
 *.csv
 *.zip
+.idea/
 
 # Build artifacts
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ venv
 *downloads
 *.csv
 *.zip
-.idea/
 
 # Build artifacts
 build/

--- a/README.md
+++ b/README.md
@@ -134,10 +134,11 @@ Securities Reports and Quarterly Reports extract comprehensive financial data in
 
 - **Income Statement**: Revenue, operating income, net income, EPS
 - **Balance Sheet**: Assets, liabilities, equity, book value per share
+- **Debt Details**: Short/long-term loans, bonds payable, commercial paper, lease obligations
 - **Cash Flow Statement**: Operating, investing, and financing cash flows
 - **Financial Ratios**: ROE, equity ratio, and more
 
-**Accounting Standards**: Both **Japan GAAP** (Generally Accepted Accounting Principles - Japan's domestic standard) and **IFRS** (International Financial Reporting Standards - used by global firms and airlines) are fully supported. The parser automatically detects the accounting standard and extracts cash flows using the appropriate XBRL elements.
+**Accounting Standards**: Both **Japan GAAP** (Generally Accepted Accounting Principles - Japan's domestic standard) and **IFRS** (International Financial Reporting Standards - used by global firms and airlines) are fully supported. The parser automatically detects the accounting standard and extracts the appropriate XBRL elements.
 
 ```python
 # Works for both Japan GAAP and IFRS companies
@@ -145,6 +146,21 @@ report = doc.parse()
 print(f"Accounting: {report.accounting_standard}")
 print(f"Operating CF: {report.operating_cash_flow}")
 print(f"Free Cash Flow: {report.operating_cash_flow + report.investing_cash_flow}")
+
+# Access detailed debt breakdown
+print(f"Short-term loans: {report.short_term_loans_payable}")
+print(f"Long-term loans: {report.long_term_loans_payable}")
+print(f"Bonds payable: {report.bonds_payable}")
+
+# Calculate total financial debt
+total_debt = sum(filter(None, [
+    report.short_term_loans_payable,
+    report.long_term_loans_payable,
+    report.bonds_payable,
+    report.current_portion_long_term_loans_payable,
+    report.commercial_paper,
+]))
+print(f"Total debt: ¥{total_debt:,.0f}")
 ```
 
 ## LLM Analysis (Optional)

--- a/README.md
+++ b/README.md
@@ -115,15 +115,36 @@ if hasattr(report, 'holder_name'):
     print(report.target_company)
     print(report.ownership_pct)
 
-# Securities Report
+# Securities Report (supports both Japan GAAP and IFRS)
 if hasattr(report, 'net_sales'):
     print(report.filer_name)
     print(report.net_sales)
+    print(report.operating_cash_flow)
+    print(report.investing_cash_flow)
     print(report.fiscal_year_end)
 
 # All reports have these
 print(report.fields())      # List available fields
 print(report.to_dict())     # Export as dictionary
+```
+
+## Financial Data Support
+
+Securities Reports and Quarterly Reports extract comprehensive financial data including:
+
+- **Income Statement**: Revenue, operating income, net income, EPS
+- **Balance Sheet**: Assets, liabilities, equity, book value per share
+- **Cash Flow Statement**: Operating, investing, and financing cash flows
+- **Financial Ratios**: ROE, equity ratio, and more
+
+**Accounting Standards**: Both **Japan GAAP** (Generally Accepted Accounting Principles - Japan's domestic standard) and **IFRS** (International Financial Reporting Standards - used by global firms and airlines) are fully supported. The parser automatically detects the accounting standard and extracts cash flows using the appropriate XBRL elements.
+
+```python
+# Works for both Japan GAAP and IFRS companies
+report = doc.parse()
+print(f"Accounting: {report.accounting_standard}")
+print(f"Operating CF: {report.operating_cash_flow}")
+print(f"Free Cash Flow: {report.operating_cash_flow + report.investing_cash_flow}")
 ```
 
 ## LLM Analysis (Optional)

--- a/edinet_tools/parsers/securities.py
+++ b/edinet_tools/parsers/securities.py
@@ -63,6 +63,15 @@ ELEMENT_MAP = {
     'net_assets_fs': 'jppfs_cor:NetAssets',
     'total_liabilities_fs': 'jppfs_cor:Liabilities',
 
+    # === Balance Sheet - Debt Details ===
+    'short_term_loans_payable': 'jppfs_cor:ShortTermLoansPayable',
+    'long_term_loans_payable': 'jppfs_cor:LongTermLoansPayable',
+    'bonds_payable': 'jppfs_cor:BondsPayable',
+    'current_portion_long_term_loans_payable': 'jppfs_cor:CurrentPortionOfLongTermLoansPayable',
+    'lease_obligations_current': 'jppfs_cor:LeaseObligationsCL',
+    'lease_obligations_noncurrent': 'jppfs_cor:LeaseObligationsNCL',
+    'commercial_paper': 'jppfs_cor:CommercialPaper',
+
     # === Cash Flow Statement Elements (Fallback for companies without Summary section) ===
     'operating_cf_cfs': 'jpcrp_cor:CashFlowsFromOperatingActivities',
     'investing_cf_cfs': 'jpcrp_cor:CashFlowsFromInvestmentActivities',
@@ -89,6 +98,10 @@ IFRS_FALLBACK_MAP = {
     'jppfs_cor:Assets': 'jpigp_cor:AssetsIFRS',
     'jppfs_cor:NetAssets': 'jpigp_cor:EquityIFRS',
     'jppfs_cor:Liabilities': 'jpigp_cor:LiabilitiesIFRS',
+    # Debt elements
+    'jppfs_cor:ShortTermLoansPayable': 'jpigp_cor:ShortTermBorrowingsIFRS',
+    'jppfs_cor:LongTermLoansPayable': 'jpigp_cor:LongTermBorrowingsIFRS',
+    'jppfs_cor:BondsPayable': 'jpigp_cor:BondsPayableIFRS',
 }
 
 
@@ -124,6 +137,15 @@ class SecuritiesReport(ParsedReport):
     total_assets: int | None = None
     net_assets: int | None = None
     total_liabilities: int | None = None
+
+    # Balance Sheet - Debt Details
+    short_term_loans_payable: int | None = None
+    long_term_loans_payable: int | None = None
+    bonds_payable: int | None = None
+    current_portion_long_term_loans_payable: int | None = None
+    lease_obligations_current: int | None = None
+    lease_obligations_noncurrent: int | None = None
+    commercial_paper: int | None = None
 
     # Cash Flow
     operating_cash_flow: int | None = None
@@ -252,6 +274,15 @@ def parse_securities_report(document) -> SecuritiesReport:
     )
     total_liabilities = get_fin('total_liabilities_fs', 'CurrentYearInstant')
 
+    # Debt details
+    short_term_loans_payable = get_fin('short_term_loans_payable', 'CurrentYearInstant')
+    long_term_loans_payable = get_fin('long_term_loans_payable', 'CurrentYearInstant')
+    bonds_payable = get_fin('bonds_payable', 'CurrentYearInstant')
+    current_portion_ltd = get_fin('current_portion_long_term_loans_payable', 'CurrentYearInstant')
+    lease_obligations_current = get_fin('lease_obligations_current', 'CurrentYearInstant')
+    lease_obligations_noncurrent = get_fin('lease_obligations_noncurrent', 'CurrentYearInstant')
+    commercial_paper = get_fin('commercial_paper', 'CurrentYearInstant')
+
     # Cash flow - Multi-tier fallback:
     # 1. Japan GAAP Summary (jpcrp_cor)
     # 2. IFRS Summary (jpcrp_cor with IFRS suffix)
@@ -338,6 +369,15 @@ def parse_securities_report(document) -> SecuritiesReport:
         total_assets=total_assets,
         net_assets=net_assets,
         total_liabilities=total_liabilities,
+
+        # Balance Sheet - Debt Details
+        short_term_loans_payable=short_term_loans_payable,
+        long_term_loans_payable=long_term_loans_payable,
+        bonds_payable=bonds_payable,
+        current_portion_long_term_loans_payable=current_portion_ltd,
+        lease_obligations_current=lease_obligations_current,
+        lease_obligations_noncurrent=lease_obligations_noncurrent,
+        commercial_paper=commercial_paper,
 
         # Cash Flow
         operating_cash_flow=operating_cf,

--- a/edinet_tools/parsers/securities.py
+++ b/edinet_tools/parsers/securities.py
@@ -179,6 +179,14 @@ class SecuritiesReport(ParsedReport):
         return f"SecuritiesReport(filer='{filer}', fy_end={fy})"
 
 
+def _coalesce(*values):
+    """Return the first non-None value."""
+    for v in values:
+        if v is not None:
+            return v
+    return None
+
+
 def parse_securities_report(document) -> SecuritiesReport:
     """
     Parse a Securities Report document.
@@ -234,43 +242,43 @@ def parse_securities_report(document) -> SecuritiesReport:
         return extract_financial(csv_files, element_id, period, is_consolidated, IFRS_FALLBACK_MAP)
 
     # Try summary elements first, then fall back to FS elements
-    net_sales = (
-        get_fin('net_sales_summary', 'CurrentYearDuration') or
-        get_fin('net_sales_fs', 'CurrentYearDuration')
+    net_sales = _coalesce(
+        get_fin('net_sales_summary', 'CurrentYearDuration'),
+        get_fin('net_sales_fs', 'CurrentYearDuration'),
     )
     operating_income = get_fin('operating_income_fs', 'CurrentYearDuration')
-    ordinary_income = (
-        get_fin('ordinary_income_summary', 'CurrentYearDuration') or
-        get_fin('ordinary_income_fs', 'CurrentYearDuration')
+    ordinary_income = _coalesce(
+        get_fin('ordinary_income_summary', 'CurrentYearDuration'),
+        get_fin('ordinary_income_fs', 'CurrentYearDuration'),
     )
-    net_income = (
-        get_fin('net_income_summary', 'CurrentYearDuration') or
-        get_fin('net_income_fs', 'CurrentYearDuration')
+    net_income = _coalesce(
+        get_fin('net_income_summary', 'CurrentYearDuration'),
+        get_fin('net_income_fs', 'CurrentYearDuration'),
     )
 
     # Prior year
-    prior_net_sales = (
-        get_fin('net_sales_summary', 'Prior1YearDuration') or
-        get_fin('net_sales_fs', 'Prior1YearDuration')
+    prior_net_sales = _coalesce(
+        get_fin('net_sales_summary', 'Prior1YearDuration'),
+        get_fin('net_sales_fs', 'Prior1YearDuration'),
     )
     prior_operating_income = get_fin('operating_income_fs', 'Prior1YearDuration')
-    prior_ordinary_income = (
-        get_fin('ordinary_income_summary', 'Prior1YearDuration') or
-        get_fin('ordinary_income_fs', 'Prior1YearDuration')
+    prior_ordinary_income = _coalesce(
+        get_fin('ordinary_income_summary', 'Prior1YearDuration'),
+        get_fin('ordinary_income_fs', 'Prior1YearDuration'),
     )
-    prior_net_income = (
-        get_fin('net_income_summary', 'Prior1YearDuration') or
-        get_fin('net_income_fs', 'Prior1YearDuration')
+    prior_net_income = _coalesce(
+        get_fin('net_income_summary', 'Prior1YearDuration'),
+        get_fin('net_income_fs', 'Prior1YearDuration'),
     )
 
     # Balance sheet
-    total_assets = (
-        get_fin('total_assets_summary', 'CurrentYearInstant') or
-        get_fin('total_assets_fs', 'CurrentYearInstant')
+    total_assets = _coalesce(
+        get_fin('total_assets_summary', 'CurrentYearInstant'),
+        get_fin('total_assets_fs', 'CurrentYearInstant'),
     )
-    net_assets = (
-        get_fin('net_assets_summary', 'CurrentYearInstant') or
-        get_fin('net_assets_fs', 'CurrentYearInstant')
+    net_assets = _coalesce(
+        get_fin('net_assets_summary', 'CurrentYearInstant'),
+        get_fin('net_assets_fs', 'CurrentYearInstant'),
     )
     total_liabilities = get_fin('total_liabilities_fs', 'CurrentYearInstant')
 
@@ -288,25 +296,25 @@ def parse_securities_report(document) -> SecuritiesReport:
     # 2. IFRS Summary (jpcrp_cor with IFRS suffix)
     # 3. Japan GAAP detailed statement (jppfs_cor)
     # 4. IFRS detailed statement (jpigp_cor)
-    operating_cf = (
-        get_fin('operating_cf_summary', 'CurrentYearDuration') or
-        get_fin('operating_cf_ifrs_summary', 'CurrentYearDuration') or
-        get_fin('operating_cf_cfs', 'CurrentYearDuration') or
-        get_fin('operating_cf_ifrs', 'CurrentYearDuration')
+    operating_cf = _coalesce(
+        get_fin('operating_cf_summary', 'CurrentYearDuration'),
+        get_fin('operating_cf_ifrs_summary', 'CurrentYearDuration'),
+        get_fin('operating_cf_cfs', 'CurrentYearDuration'),
+        get_fin('operating_cf_ifrs', 'CurrentYearDuration'),
     )
 
-    investing_cf = (
-        get_fin('investing_cf_summary', 'CurrentYearDuration') or
-        get_fin('investing_cf_ifrs_summary', 'CurrentYearDuration') or
-        get_fin('investing_cf_cfs', 'CurrentYearDuration') or
-        get_fin('investing_cf_ifrs', 'CurrentYearDuration')
+    investing_cf = _coalesce(
+        get_fin('investing_cf_summary', 'CurrentYearDuration'),
+        get_fin('investing_cf_ifrs_summary', 'CurrentYearDuration'),
+        get_fin('investing_cf_cfs', 'CurrentYearDuration'),
+        get_fin('investing_cf_ifrs', 'CurrentYearDuration'),
     )
 
-    financing_cf = (
-        get_fin('financing_cf_summary', 'CurrentYearDuration') or
-        get_fin('financing_cf_ifrs_summary', 'CurrentYearDuration') or
-        get_fin('financing_cf_cfs', 'CurrentYearDuration') or
-        get_fin('financing_cf_ifrs', 'CurrentYearDuration')
+    financing_cf = _coalesce(
+        get_fin('financing_cf_summary', 'CurrentYearDuration'),
+        get_fin('financing_cf_ifrs_summary', 'CurrentYearDuration'),
+        get_fin('financing_cf_cfs', 'CurrentYearDuration'),
+        get_fin('financing_cf_ifrs', 'CurrentYearDuration'),
     )
 
     # Per-share metrics

--- a/test/test_debt_fields.py
+++ b/test/test_debt_fields.py
@@ -1,0 +1,263 @@
+"""Unit tests for debt field extraction from Securities Reports."""
+import pytest
+from unittest.mock import Mock, patch
+from edinet_tools.parsers.securities import SecuritiesReport, parse_securities_report
+
+
+class TestDebtFieldExtraction:
+    """Test extraction of debt-related fields from securities reports."""
+
+    def test_debt_fields_exist_on_securities_report(self):
+        """SecuritiesReport has all debt-related fields."""
+        report = SecuritiesReport(
+            doc_id='S100TEST',
+            doc_type_code='120',
+        )
+
+        # Verify all debt fields exist
+        assert hasattr(report, 'short_term_loans_payable')
+        assert hasattr(report, 'long_term_loans_payable')
+        assert hasattr(report, 'bonds_payable')
+        assert hasattr(report, 'current_portion_long_term_loans_payable')
+        assert hasattr(report, 'lease_obligations_current')
+        assert hasattr(report, 'lease_obligations_noncurrent')
+        assert hasattr(report, 'commercial_paper')
+
+    def test_debt_fields_in_to_dict(self):
+        """Debt fields are included in to_dict() export."""
+        report = SecuritiesReport(
+            doc_id='S100TEST',
+            doc_type_code='120',
+            short_term_loans_payable=1_000_000_000,
+            long_term_loans_payable=5_000_000_000,
+            bonds_payable=2_000_000_000,
+        )
+
+        data = report.to_dict()
+        assert data['short_term_loans_payable'] == 1_000_000_000
+        assert data['long_term_loans_payable'] == 5_000_000_000
+        assert data['bonds_payable'] == 2_000_000_000
+
+    def test_debt_fields_default_to_none(self):
+        """Debt fields default to None when not provided."""
+        report = SecuritiesReport(
+            doc_id='S100TEST',
+            doc_type_code='120',
+        )
+
+        assert report.short_term_loans_payable is None
+        assert report.long_term_loans_payable is None
+        assert report.bonds_payable is None
+        assert report.current_portion_long_term_loans_payable is None
+        assert report.lease_obligations_current is None
+        assert report.lease_obligations_noncurrent is None
+        assert report.commercial_paper is None
+
+    def test_parse_securities_report_extracts_debt_fields(self):
+        """parse_securities_report() extracts debt fields from CSV data."""
+        # Mock CSV data with debt elements
+        mock_csv_files = [
+            {
+                'filename': 'test.csv',
+                'data': [
+                    {
+                        '要素ID': 'jppfs_cor:ShortTermLoansPayable',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '1000000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jppfs_cor:LongTermLoansPayable',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '5000000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jppfs_cor:BondsPayable',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '2000000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jppfs_cor:CurrentPortionOfLongTermLoansPayable',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '500000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jppfs_cor:CommercialPaper',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '300000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jppfs_cor:LeaseObligationsCL',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '100000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jppfs_cor:LeaseObligationsNCL',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '200000000',
+                        '単位': 'JPY',
+                    },
+                    # Add some basic identification fields
+                    {
+                        '要素ID': 'jpdei_cor:EDINETCodeDEI',
+                        'コンテキストID': 'FilingDateInstant',
+                        '値': 'E12345',
+                        '単位': None,
+                    },
+                    {
+                        '要素ID': 'jpdei_cor:SecurityCodeDEI',
+                        'コンテキストID': 'FilingDateInstant',
+                        '値': '1234',
+                        '単位': None,
+                    },
+                ]
+            }
+        ]
+
+        # Mock document object
+        mock_doc = Mock()
+        mock_doc.doc_id = 'S100TEST'
+        mock_doc.doc_type_code = '120'
+        mock_doc.fetch.return_value = b'fake_zip_data'
+
+        with patch('edinet_tools.parsers.securities.extract_csv_from_zip', return_value=mock_csv_files):
+            report = parse_securities_report(mock_doc)
+
+        # Verify debt fields were extracted
+        assert report.short_term_loans_payable == 1_000_000_000
+        assert report.long_term_loans_payable == 5_000_000_000
+        assert report.bonds_payable == 2_000_000_000
+        assert report.current_portion_long_term_loans_payable == 500_000_000
+        assert report.commercial_paper == 300_000_000
+        assert report.lease_obligations_current == 100_000_000
+        assert report.lease_obligations_noncurrent == 200_000_000
+
+    def test_parse_securities_report_handles_missing_debt_fields(self):
+        """parse_securities_report() handles missing debt fields gracefully."""
+        # Mock CSV data without debt elements
+        mock_csv_files = [
+            {
+                'filename': 'test.csv',
+                'data': [
+                    {
+                        '要素ID': 'jpdei_cor:EDINETCodeDEI',
+                        'コンテキストID': 'FilingDateInstant',
+                        '値': 'E12345',
+                        '単位': None,
+                    },
+                ]
+            }
+        ]
+
+        # Mock document object
+        mock_doc = Mock()
+        mock_doc.doc_id = 'S100TEST'
+        mock_doc.doc_type_code = '120'
+        mock_doc.fetch.return_value = b'fake_zip_data'
+
+        with patch('edinet_tools.parsers.securities.extract_csv_from_zip', return_value=mock_csv_files):
+            report = parse_securities_report(mock_doc)
+
+        # Verify debt fields are None when not present
+        assert report.short_term_loans_payable is None
+        assert report.long_term_loans_payable is None
+        assert report.bonds_payable is None
+
+    def test_total_debt_calculation(self):
+        """Test calculating total debt from individual components."""
+        report = SecuritiesReport(
+            doc_id='S100TEST',
+            doc_type_code='120',
+            short_term_loans_payable=1_000_000_000,
+            long_term_loans_payable=5_000_000_000,
+            bonds_payable=2_000_000_000,
+            current_portion_long_term_loans_payable=500_000_000,
+            commercial_paper=300_000_000,
+        )
+
+        # Calculate total financial debt (excluding lease obligations)
+        total_debt = sum(filter(None, [
+            report.short_term_loans_payable,
+            report.long_term_loans_payable,
+            report.bonds_payable,
+            report.current_portion_long_term_loans_payable,
+            report.commercial_paper,
+        ]))
+
+        assert total_debt == 8_800_000_000
+
+    def test_debt_to_equity_ratio_calculation(self):
+        """Test D/E ratio calculation with extracted debt fields."""
+        report = SecuritiesReport(
+            doc_id='S100TEST',
+            doc_type_code='120',
+            short_term_loans_payable=1_000_000_000,
+            long_term_loans_payable=5_000_000_000,
+            bonds_payable=2_000_000_000,
+            net_assets=10_000_000_000,
+        )
+
+        total_debt = sum(filter(None, [
+            report.short_term_loans_payable,
+            report.long_term_loans_payable,
+            report.bonds_payable,
+        ]))
+
+        de_ratio = (total_debt / report.net_assets) * 100 if report.net_assets else None
+
+        assert de_ratio is not None
+        assert de_ratio == 80.0  # 8B debt / 10B equity = 80%
+
+    def test_ifrs_debt_fields_extraction(self):
+        """Test extraction of debt fields from IFRS reports."""
+        # Mock CSV data with IFRS debt elements
+        mock_csv_files = [
+            {
+                'filename': 'test.csv',
+                'data': [
+                    {
+                        '要素ID': 'jpigp_cor:ShortTermBorrowingsIFRS',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '1500000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jpigp_cor:LongTermBorrowingsIFRS',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '6000000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jpigp_cor:BondsPayableIFRS',
+                        'コンテキストID': 'CurrentYearInstant',
+                        '値': '2500000000',
+                        '単位': 'JPY',
+                    },
+                    {
+                        '要素ID': 'jpdei_cor:EDINETCodeDEI',
+                        'コンテキストID': 'FilingDateInstant',
+                        '値': 'E12345',
+                        '単位': None,
+                    },
+                ]
+            }
+        ]
+
+        # Mock document object
+        mock_doc = Mock()
+        mock_doc.doc_id = 'S100TEST'
+        mock_doc.doc_type_code = '120'
+        mock_doc.fetch.return_value = b'fake_zip_data'
+
+        with patch('edinet_tools.parsers.securities.extract_csv_from_zip', return_value=mock_csv_files):
+            report = parse_securities_report(mock_doc)
+
+        # Verify IFRS debt fields were extracted using fallback mapping
+        assert report.short_term_loans_payable == 1_500_000_000
+        assert report.long_term_loans_payable == 6_000_000_000
+        assert report.bonds_payable == 2_500_000_000

--- a/test/test_ifrs_cash_flow.py
+++ b/test/test_ifrs_cash_flow.py
@@ -1,0 +1,64 @@
+"""
+Test IFRS cash flow extraction.
+
+Tests both IFRS (JAL) and Japan GAAP (Shizuki Electric) companies to ensure
+the 4-tier fallback logic works for both accounting standards.
+
+These are integration tests that fetch real data from EDINET API.
+"""
+import pytest
+from edinet_tools import entity_by_ticker, parse
+
+
+@pytest.mark.integration
+def test_ifrs_company():
+    """Test IFRS company (JAL - Airlines) extracts cash flows correctly."""
+    
+    jal = entity_by_ticker('9201')
+    docs = list(jal.documents(days=730))
+    sec_report = [d for d in docs if d.doc_type_code == '120'][0]
+    
+    report = parse(sec_report)
+    
+    # Verify accounting standard
+    assert report.accounting_standard == 'IFRS', "JAL should use IFRS"
+
+    # Verify cash flows are extracted (not None or 0)
+    assert report.operating_cash_flow, "Operating CF should be extracted"
+    assert report.investing_cash_flow, "Investing CF should be extracted"
+    assert report.financing_cash_flow, "Financing CF should be extracted"
+
+    # Verify values are reasonable (JAL is a large airline)
+    assert report.operating_cash_flow > 100e9, "Operating CF should be >¥100B"
+    assert report.investing_cash_flow < 0, "Investing CF should be negative (CapEx)"
+
+    # FCF should be positive for airlines in recovery
+    fcf = report.operating_cash_flow + report.investing_cash_flow
+    assert fcf > 0, f"FCF should be positive, got ¥{fcf/1e9:.2f}B"
+
+@pytest.mark.integration
+def test_japan_gaap_company():
+    """Test Japan GAAP company (Shizuki Electric) still works (regression test)."""
+    
+    shizuki = entity_by_ticker('6994')
+    docs = shizuki.documents(doc_type='120', days=730)
+    latest = docs[0]
+    
+    report = parse(latest)
+    
+    # Verify accounting standard
+    assert report.accounting_standard == 'Japan GAAP', "Shizuki should use Japan GAAP"
+
+    # Verify cash flows are extracted (regression test - should still work)
+    assert report.operating_cash_flow, "Operating CF should be extracted"
+    assert report.investing_cash_flow, "Investing CF should be extracted"
+    assert report.financing_cash_flow, "Financing CF should be extracted"
+
+    # Verify values are reasonable (Shizuki is a small manufacturer)
+    assert report.operating_cash_flow > 1e9, "Operating CF should be >¥1B"
+    assert report.investing_cash_flow < 0, "Investing CF should be negative (CapEx)"
+
+    # FCF should be positive
+    fcf = report.operating_cash_flow + report.investing_cash_flow
+    assert fcf > 0, f"FCF should be positive, got ¥{fcf/1e9:.2f}B"
+


### PR DESCRIPTION
## Summary

Enhances balance sheet parsing with comprehensive financial data extraction:

- **IFRS cash flow support**: Auto-detects IFRS vs Japan GAAP and extracts cash flows using appropriate XBRL elements (supports airlines and global companies)
- **Debt field extraction**: Extracts 7 detailed debt components from balance sheets
- **Zero-value bug fix**: Replace `or`-chain fallbacks with `_coalesce()` helper to correctly handle legitimate zero values
- **Dual standard support**: Both features work for Japan GAAP and IFRS companies with fallback mappings
- **Comprehensive tests**: Added 8 unit tests covering extraction, validation, and edge cases

## Changes

### IFRS Cash Flow Statement Support
- Add IFRS-specific XBRL element mappings for cash flows
- Implement multi-tier fallback: Summary (GAAP) → Summary (IFRS) → Direct (GAAP) → Direct (IFRS)

### Debt Field Extraction
- Add 7 debt-related fields to `SecuritiesReport` dataclass
- Implement GAAP and IFRS element mappings with fallback
- Add comprehensive unit tests in `test/test_debt_fields.py`

### Bug Fix: or-chain zero-value handling
- The `or` operator treats `0` as falsy, causing legitimate zero values to fall through to the next source
- Added `_coalesce()` helper that returns the first non-`None` value
- Applied to all fallback chains (income statement, balance sheet, cash flow)

## Test Plan

- [x] All existing unit tests pass
- [x] 8 new unit tests for debt field extraction (all passing)
- [x] Tested with GAAP companies (e.g., TSE:6994)
- [x] Tested with IFRS companies (e.g., TSE:9201)
- [x] Verified fallback mappings work correctly