### PR TITLE
Release 0.4.3

### DIFF
--- a/edinet_tools/__init__.py
+++ b/edinet_tools/__init__.py
@@ -4,13 +4,13 @@ EDINET Tools - Python package for accessing Japanese corporate financial data.
 Python library for Japanese financial disclosure data.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __author__ = "Matt Helmer"
 __description__ = "Python package for accessing Japanese corporate financial data from EDINET"
 
 # Core API
 from .client import EdinetClient  # Deprecated, but kept for migration
-from ._client import configure, documents
+from ._client import configure, documents, fetch_and_parse
 from .timezone import today_jst
 from .config import SUPPORTED_DOC_TYPES as DOCUMENT_TYPES
 
@@ -52,6 +52,7 @@ __all__ = [
     # Configuration
     "configure",
     "documents",
+    "fetch_and_parse",
     "today_jst",
     "DOCUMENT_TYPES",
     "__version__",

--- a/edinet_tools/_client.py
+++ b/edinet_tools/_client.py
@@ -52,6 +52,26 @@ def configure(api_key: Optional[str] = None) -> None:
     _client = None  # Reset so next _get_client() uses new config
 
 
+def fetch_and_parse(doc_id: str, doc_type_code: str):
+    """
+    Fetch and parse a specific EDINET document by ID.
+
+    Useful when you already know the document ID (e.g., from a cached filing
+    index) and want to skip the date-based document listing.
+
+    Args:
+        doc_id: EDINET document ID (e.g., 'S100ABC')
+        doc_type_code: Document type code (e.g., '120', '180', '350')
+
+    Returns:
+        ParsedReport subclass appropriate for the document type
+    """
+    from .document import Document
+
+    doc = Document({'docID': doc_id, 'docTypeCode': doc_type_code}, client=_get_client())
+    return doc.parse()
+
+
 def documents(date: Optional[str] = None, doc_type: Optional[str] = None) -> list:
     """
     Get all documents filed on a specific date.

--- a/edinet_tools/entity.py
+++ b/edinet_tools/entity.py
@@ -194,6 +194,7 @@ def _build_entity_from_classifier(edinet_code: str, classifier: EntityClassifier
         'ticker': ticker,
         'is_listed': raw.get('is_listed', False),
         'submitter_type': raw.get('submitter_type'),
+        'industry': raw.get('industry') or None,
     }
     return Entity(data)
 

--- a/edinet_tools/entity_classifier.py
+++ b/edinet_tools/entity_classifier.py
@@ -102,7 +102,7 @@ class EntityClassifier:
                         self._fund_edinet_codes.add(edinet_code)
 
         # Load EDINET codes (Shift-JIS encoded)
-        # Columns: 0=EDINET Code, 1=Type, 2=Listed/Unlisted, 6=Name JP, 7=Name EN, 11=Securities Code
+        # Columns: 0=EDINET Code, 1=Type, 2=Listed/Unlisted, 6=Name JP, 7=Name EN, 10=Industry, 11=Securities Code
         with open(self.edinet_codes_path, 'r', encoding='cp932', errors='replace') as f:
             reader = csv.reader(f)
             next(reader)  # Skip metadata row
@@ -116,6 +116,7 @@ class EntityClassifier:
                             'is_listed': row[2].strip() == 'Listed company',
                             'name_jp': row[6].strip() if len(row) > 6 else None,
                             'name_en': row[7].strip() if len(row) > 7 else None,
+                            'industry': row[10].strip() if len(row) > 10 else None,
                             'securities_code': row[11].strip() if len(row) > 11 else None,
                         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "edinet-tools"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
     {name = "Matt Helmer"},
 ]

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -294,3 +294,11 @@ class TestEntityDocuments:
 
         assert len(docs) > 0
         assert all(isinstance(d, Document) for d in docs)
+
+def test_entity_has_industry_attribute():
+    """Verify Entity objects expose the industry field."""
+    from edinet_tools import entity_by_edinet_code
+    # Toyota — should have industry data in the bundled CSV
+    entity = entity_by_edinet_code('E02144')
+    assert hasattr(entity, 'industry')
+    # industry may be None for some entities, but the attribute must exist

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -216,3 +216,8 @@ class TestEntityAutoClient:
         with patch.object(doc, 'fetch', return_value=b''):
             result = doc.parse()
             assert isinstance(result, ParsedReport)
+
+    def test_fetch_and_parse_is_exported(self):
+        """Verify fetch_and_parse is importable from the public API."""
+        from edinet_tools import fetch_and_parse
+        assert callable(fetch_and_parse)


### PR DESCRIPTION
feat: add fetch_and_parse API, expose industry field on Entity

- `fetch_and_parse(doc_id, doc_type_code)`: parse documents by ID directly
- Entity objects now expose `.industry` from bundled EDINET CSV
- Two new tests
348 tests passing. All additive changes.