### PR TITLE
v0.5.0: Complete EDINET document type coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv
 *.csv
 !edinet_tools/data/*.csv
 *.zip
+scripts/
 
 # Build artifacts
 build/

--- a/README.md
+++ b/README.md
@@ -1,162 +1,163 @@
-# EDINET Tools
+# edinet-tools
 
-> **Python SDK for Japanese corporate disclosure data**
-
-Access Japan's [EDINET](https://disclosure2.edinet-fsa.go.jp/) system — the official repository for securities reports, earnings, large shareholding notices, and other regulatory filings from 11,000+ Japanese companies.
+Python library for Japan's [EDINET](https://disclosure2.edinet-fsa.go.jp/) disclosure system — the official source for securities reports, shareholding notices, tender offers, and other regulatory filings from listed Japanese companies.
 
 ```python
 import edinet_tools
 
-docs = edinet_tools.documents("2026-01-20")  # Get all filings for a date
-report = docs[0].parse()                      # Parse to typed Python object
+toyota = edinet_tools.entity("7203")
+docs = toyota.documents(days=30)
+report = docs[0].parse()  # → SecuritiesReport, LargeHoldingReport, etc.
 ```
 
-## Installation
+## Install
 
 ```bash
 pip install edinet-tools
 ```
 
-## Quick Start
+Requires Python 3.10+. No heavy dependencies — just `pandas`, `python-dateutil`, `chardet`, and `python-dotenv`.
+
+## Design
+
+edinet-tools has three layers:
+
+1. **API client** — fetch document listings and download filings in any format (XBRL, PDF, HTML)
+2. **Typed parsers** — every EDINET document type routes to a named Python dataclass with structured fields
+3. **Full capture** — elements not yet mapped to typed fields are preserved in `raw_fields`, `unmapped_fields`, and `text_blocks`, so you can explore what's available and nothing is silently dropped
+
+Each parser maps known XBRL elements to typed Python fields (dates, decimals, strings). As EDINET evolves or new elements become useful, adding a field is one line in the element map and one line on the dataclass. The architecture is designed to grow incrementally without breaking existing code.
+
+## EDINET Document Types
+
+EDINET defines 42 document types spanning corporate disclosure, capital markets activity, and governance reporting. edinet-tools provides typed parsers for all of them.
+
+| Code | Family | Description |
+|------|--------|-------------|
+| 120, 130 | Securities Reports | Annual reports — financials, governance, business overview (J-GAAP + IFRS) |
+| 140, 150 | Quarterly Reports | Quarterly financials (abolished April 2024) |
+| 160, 170 | Semi-Annual Reports | Semi-annual reports, primarily investment funds |
+| 180, 190 | Extraordinary Reports | Material events — M&A, management changes, restructuring |
+| 220, 230 | Treasury Stock | Share buyback authorization and execution status |
+| 235, 236 | Internal Control | J-SOX evaluation results — internal control effectiveness |
+| 135, 136 | Confirmation Documents | CEO/CFO attestation (primarily PDF) |
+| 200, 210 | Parent Company Reports | Parent-subsidiary relationships |
+| 350, 360 | Large Shareholding | 5%+ ownership filings — filer, target, ownership percentage |
+| 370, 380 | Shareholding Changes | Position changes for large holders |
+| 240, 250 | Tender Offer Registration | Public tender offer filings |
+| 260 | Tender Offer Withdrawal | Withdrawal of tender offers |
+| 270, 280 | Tender Offer Reports | Tender offer completion — outcome, final holdings |
+| 290, 300 | Statement of Opinion | Target company's board opinion on a tender offer |
+| 310, 320 | Response to Questions | Regulatory Q&A during tender offer process |
+| 330, 340 | Exemption Application | Exemption from separate purchase prohibition |
+| 030, 040 | Securities Registration | New securities registration statements (primarily funds) |
+| 010, 020 | Securities Notification | Securities issuance notifications |
+| 050 | Registration Withdrawal | Withdrawal of securities registration |
+| 070, 080, 090 | Shelf Registration | Shelf registration for future bond/equity issuance |
+| 060 | Issuance Notification | Issuance registration notifications |
+| 100 | Issuance Supplementary | Supplementary shelf registration drawdown documents |
+| 110 | Issuance Withdrawal | Withdrawal of issuance registration |
+
+Amendments (even-numbered codes like 130, 150, 190) route to the same parser as their base type and set `is_amendment = True`.
+
+```python
+from edinet_tools import supported_doc_types, doc_type
+
+supported_doc_types()  # All 42 codes with typed parsers
+
+dt = doc_type("235")
+print(dt.name_en)  # "Internal Control Report"
+print(dt.name_jp)  # "内部統制報告書"
+```
+
+## Usage
+
+### Entity Lookup
 
 ```python
 import edinet_tools
 
-# Look up any company
 toyota = edinet_tools.entity("7203")      # By ticker
-toyota = edinet_tools.entity("Toyota")    # By name
+toyota = edinet_tools.entity("Toyota")    # By name search
 print(toyota.name, toyota.edinet_code)    # TOYOTA MOTOR CORPORATION E02144
 
-# Search companies
 banks = edinet_tools.search("bank", limit=5)
+```
 
-# Get filings (requires EDINET_API_KEY)
-docs = toyota.documents(days=30)
-for doc in docs[:3]:
-    print(f"{doc.filing_datetime}: {doc.doc_type_name}")
+### Fetching Documents
 
-# Parse a document into a typed object
-report = docs[0].parse()
-print(type(report).__name__)  # SecuritiesReport, LargeHoldingReport, etc.
+```python
+# All filings for a date (requires EDINET_API_KEY)
+docs = edinet_tools.documents("2026-01-20")
 
-# Get all documents filed on a specific date
-all_filings = edinet_tools.documents("2026-01-20")
+# Filter by company and type
+earnings = toyota.documents(doc_type="120", days=365)
+```
+
+### Parsing
+
+```python
+report = doc.parse()
+
+# Securities Report — financials with J-GAAP and IFRS support
+report.net_sales
+report.operating_cash_flow
+report.roe
+report.accounting_standard  # "Japan GAAP" or "IFRS"
+
+# Large Shareholding Report
+report.filer_name
+report.target_company
+report.ownership_pct
+
+# Tender Offer
+report.acquirer_name
+report.target_name
+report.holding_ratio_after
+
+# Any report
+report.fields()     # List available typed fields
+report.to_dict()    # Export as dictionary
+report.raw_fields   # All XBRL elements by element ID
+report.text_blocks  # Narrative text block content
+```
+
+### Download Formats
+
+```python
+from edinet_tools.api import fetch_document
+
+csv_zip = fetch_document("S100ABC")            # XBRL CSV (default)
+pdf = fetch_document("S100ABC", type=2)        # PDF
+html_zip = fetch_document("S100ABC", type=1)   # HTML documents
 ```
 
 ## Configuration
 
-Get your free API key from [EDINET](https://disclosure2.edinet-fsa.go.jp/) and set it:
+Get a free API key from [EDINET](https://disclosure2.edinet-fsa.go.jp/) ([video walkthrough](https://youtu.be/2ao-CZS-BtQ?t=63)):
 
 ```bash
 export EDINET_API_KEY=your_key_here
 ```
 
-Or create a `.env` file in your project:
-
-```dotenv
-EDINET_API_KEY=your_edinet_key
-```
-
-## Document Types
-
-All 30+ EDINET document types are supported. These common types have specialized typed parsers:
-
-| Code | Type | Parser Class |
-|------|------|--------------|
-| 120 | Securities Report | `SecuritiesReport` |
-| 140 | Quarterly Report | `QuarterlyReport` |
-| 160 | Semi-Annual Report | `SemiAnnualReport` |
-| 180 | Extraordinary Report | `ExtraordinaryReport` |
-| 220 | Treasury Stock Report | `TreasuryStockReport` |
-| 240 | Tender Offer Registration | `TenderOfferReport` |
-| 350 | Large Shareholding | `LargeHoldingReport` |
-
-All other document types parse to `RawReport` with access to the underlying XBRL data.
-
-```python
-# Filter by document type
-earnings = toyota.documents(doc_type="120")
-
-# Get document type info
-dt = edinet_tools.doc_type("120")
-print(dt.name_en)  # Securities Report
-print(dt.name_jp)  # 有価証券報告書
-```
-
-## Parsing Documents
-
-Documents parse into typed Python objects with structured fields:
-
-```python
-report = doc.parse()
-
-# Large Shareholding Report
-if isinstance(report, edinet_tools.LargeHoldingReport):
-    print(report.filer_name)
-    print(report.target_company)
-    print(report.ownership_pct)
-    print(report.purpose)
-
-# Securities Report (Japan GAAP and IFRS)
-if isinstance(report, edinet_tools.SecuritiesReport):
-    print(report.net_sales)
-    print(report.operating_cash_flow)
-    print(report.fiscal_year_end)
-    print(report.roe)
-
-# Treasury Stock Report
-if isinstance(report, edinet_tools.TreasuryStockReport):
-    print(report.filer_name)
-    print(report.ticker)
-    print(report.has_board_authorization)
-
-# Tender Offer (TOB)
-if isinstance(report, edinet_tools.TenderOfferReport):
-    print(report.acquirer_name)
-    print(report.target_name)
-    print(report.purchase_ratio)
-    print(report.holding_ratio_after)
-
-# All reports
-print(report.fields())      # List available fields
-print(report.to_dict())     # Export as dictionary
-```
-
-## Financial Data
-
-Securities Reports extract comprehensive financial data with automatic support for both **Japan GAAP** and **IFRS** accounting standards:
-
-- **Income Statement**: Revenue, operating income, net income, EPS
-- **Balance Sheet**: Assets, liabilities, equity, book value per share
-- **Debt**: Short/long-term loans, bonds payable, commercial paper, lease obligations
-- **Cash Flow**: Operating, investing, and financing cash flows
-- **Ratios**: ROE, equity ratio
-
-```python
-report = doc.parse()
-print(report.accounting_standard)        # "Japan GAAP" or "IFRS"
-print(report.operating_cash_flow)
-print(report.short_term_loans_payable)
-print(report.bonds_payable)
-```
+Or use a `.env` file. Entity lookup and parsing work without an API key — only document fetching requires one.
 
 ## Testing
 
 ```bash
-pytest tests/ -v              # Full suite (~350 tests)
-python test_runner.py --unit  # Unit tests only
+pytest tests/ -v  # 600+ tests
 ```
 
 ## Links
 
-- **PyPI**: [pypi.org/project/edinet-tools](https://pypi.org/project/edinet-tools/)
-- **GitHub**: [github.com/matthelmer/edinet-tools](https://github.com/matthelmer/edinet-tools)
-- **EDINET**: [disclosure2.edinet-fsa.go.jp](https://disclosure2.edinet-fsa.go.jp/)
+- [PyPI](https://pypi.org/project/edinet-tools/)
+- [GitHub](https://github.com/matthelmer/edinet-tools)
+- [EDINET](https://disclosure2.edinet-fsa.go.jp/)
 
 ## License
 
-MIT License
+MIT
 
 ---
 
-*Independent project, not affiliated with Japan's Financial Services Agency. Verify data independently before making financial decisions.*
+*Independent project. Not affiliated with Japan's Financial Services Agency. Verify data independently before making financial decisions.*

--- a/demo.py
+++ b/demo.py
@@ -138,6 +138,29 @@ def parse_securities_report(docs):
     print("  No doc 120 found in the last 5 days")
 
 
+def parse_internal_control(docs):
+    """Parse an internal control report (doc 235) — J-SOX compliance."""
+    print("\n--- Internal Control Report (Doc 235) ---")
+
+    for doc in docs:
+        if doc.doc_type_code in ("235", "236"):
+            report = doc.parse()  # → InternalControlReport
+            print(f"  Parser:    {type(report).__name__}")
+            print(f"  Company:   {report.company_name or report.filer_name}")
+            print(f"  Filed:     {report.filing_date}")
+            if report.representative:
+                print(f"  Signed by: {report.representative}")
+            if report.cfo:
+                print(f"  CFO:       {report.cfo}")
+            if report.evaluation_result_text:
+                preview = report.evaluation_result_text[:120].replace('\n', ' ')
+                print(f"  Evaluation: {preview}...")
+            print(f"  Amendment: {report.is_amendment}")
+            return
+
+    print("  No doc 235/236 found in the last 5 days")
+
+
 # ── 4. Doc type registry ─────────────────────────────────────────
 
 def doc_type_registry():
@@ -151,6 +174,147 @@ def doc_type_registry():
         print(f"  {dt.code}: {dt.name_en} ({dt.name_jp})")
 
 
+# ── 5. supported_doc_types() — what has a typed parser ───────────
+
+def show_supported_doc_types():
+    """Show which doc types have typed parsers (not a generic fallback)."""
+    print("\n--- Typed Parser Coverage ---")
+
+    codes = edinet_tools.supported_doc_types()
+    print(f"{len(codes)} doc types have typed parsers:\n")
+
+    # Print in groups of 8 for readability
+    for i in range(0, len(codes), 8):
+        row = codes[i:i + 8]
+        print("  " + "  ".join(row))
+
+    print()
+    # Highlight a few notable ones
+    highlights = {
+        "120": "Annual Securities Report",
+        "235": "Internal Control Report (J-SOX)",
+        "240": "Tender Offer Registration",
+        "350": "Large Shareholding Report (>5%)",
+    }
+    print("Notable types:")
+    for code, label in highlights.items():
+        print(f"  {code}: {label}")
+
+
+# ── 6. doc_type() — metadata for any code (even without a parser) ─
+
+def show_doc_type_metadata():
+    """Look up metadata for doc types, including those without typed parsers."""
+    print("\n--- Doc Type Metadata Lookup ---")
+
+    # Type 200 has metadata but no typed parser — falls back to RawReport
+    dt = edinet_tools.doc_type("200")
+    print(f"Code 200: {dt.name_en}")
+    print(f"  Japanese: {dt.name_jp}")
+    print(f"  Description: {dt.description}")
+
+    from edinet_tools.parsers import supported_doc_types
+    has_parser = "200" in supported_doc_types()
+    print(f"  Has typed parser: {has_parser}  (falls back to RawReport)")
+
+    print()
+
+    # Type 235 has both metadata AND a typed parser
+    dt2 = edinet_tools.doc_type("235")
+    print(f"Code 235: {dt2.name_en}")
+    print(f"  Japanese: {dt2.name_jp}")
+    print(f"  Description: {dt2.description}")
+    has_parser2 = "235" in supported_doc_types()
+    print(f"  Has typed parser: {has_parser2}")
+
+
+# ── 7. PDF download via fetch_document(type=2) ────────────────────
+
+def show_pdf_download():
+    """Show how to download PDF versions using the low-level API."""
+    print("\n--- PDF Download (Low-Level API) ---")
+    print("  The high-level doc.fetch() always returns the XBRL/CSV ZIP.")
+    print("  For PDF, use the low-level fetch_document() with type=2:\n")
+    print("    from edinet_tools.api import fetch_document")
+    print()
+    print("    doc_id = 'S100ABC123'")
+    print()
+    print("    # type=5 (default): XBRL-to-CSV ZIP — what parsers use")
+    print("    xbrl_bytes = fetch_document(doc_id, type=5)")
+    print()
+    print("    # type=2: PDF version of the filing")
+    print("    pdf_bytes  = fetch_document(doc_id, type=2)")
+    print("    with open('filing.pdf', 'wb') as f:")
+    print("        f.write(pdf_bytes)")
+    print()
+    print("    # type=1: HTML ZIP (full document with HTML + attachments)")
+    print("    html_zip   = fetch_document(doc_id, type=1)")
+    print()
+    print("  Type reference:")
+    print("    1 = HTML ZIP (PublicDoc, AuditDoc)")
+    print("    2 = PDF")
+    print("    3 = Attachment ZIP (AttachDoc)")
+    print("    4 = English documents ZIP (EnglishDoc)")
+    print("    5 = XBRL-to-CSV ZIP (default, used by parsers)")
+
+
+# ── 8. Shelf registration parser (Doc 080) — static example ──────
+
+def show_shelf_registration_parser():
+    """Show the ShelfRegistrationReport parser using mock data."""
+    print("\n--- Shelf Registration Parser (Doc 080) — Static Example ---")
+    print("  Parser: ShelfRegistrationReport")
+    print("  Filed when a company registers a shelf of securities")
+    print("  it may issue over a defined future period.\n")
+    print("  Key fields:")
+    print("    shelf_registration_number  Unique identifier for the registration")
+    print("    planned_period             Issuance window (Japanese text)")
+    print("    security_types             Types of securities registered")
+    print("    filing_date                Date of registration")
+    print("    filer_edinet_code          EDINET code of the issuer")
+    print()
+
+    # Show what a parsed result looks like using the parser directly with mock CSV
+    from edinet_tools.parsers.shelf_registration import (
+        parse_shelf_registration,
+        ShelfRegistrationReport,
+        ELEMENT_MAP,
+    )
+    from edinet_tools.parsers.extraction import extract_csv_from_zip
+    import io
+    import zipfile
+
+    # Build a minimal mock CSV (tab-separated, UTF-16LE as EDINET uses)
+    rows = [
+        f"{ELEMENT_MAP['filer_name']}\tlabel\tFilingDateInstant\t0\t連結\t期間\t\t\t東急不動産ホールディングス株式会社",
+        f"{ELEMENT_MAP['filer_edinet_code']}\tlabel\tFilingDateInstant\t0\t連結\t期間\t\t\tE03063",
+        f"{ELEMENT_MAP['shelf_registration_number']}\tlabel\tFilingDateInstant\t0\t連結\t期間\t\t\t第1号",
+        f"{ELEMENT_MAP['filing_date']}\tlabel\tFilingDateInstant\t0\t連結\t期間\t\t\t2024-04-01",
+        f"{ELEMENT_MAP['planned_period']}\tlabel\tFilingDateInstant\t0\t連結\t期間\t\t\t2024年4月1日から2026年3月31日まで",
+        f"{ELEMENT_MAP['security_types']}\tlabel\tFilingDateInstant\t0\t連結\t期間\t\t\t社債券",
+    ]
+    content = '\n'.join(rows)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('XBRL_TO_CSV/test.csv', content.encode('utf-16le'))
+
+    csv_files = extract_csv_from_zip(buf.getvalue())
+    report = parse_shelf_registration(
+        csv_files=csv_files,
+        doc_id='S100MOCK1',
+        doc_type_code='080',
+    )
+
+    print(f"  Result: {repr(report)}")
+    print(f"    filer_name:                {report.filer_name}")
+    print(f"    filer_edinet_code:         {report.filer_edinet_code}")
+    print(f"    shelf_registration_number: {report.shelf_registration_number}")
+    print(f"    filing_date:               {report.filing_date}")
+    print(f"    planned_period:            {report.planned_period}")
+    print(f"    security_types:            {report.security_types}")
+    print(f"    is_amendment:              {report.is_amendment}")
+
+
 # ── Main ──────────────────────────────────────────────────────────
 
 def main():
@@ -159,9 +323,19 @@ def main():
     print("EDINET Tools Quick Start")
     print("=" * 40)
 
-    # Entity lookup works without an API key
+    # Entity lookup and doc type features work without an API key
     entity_lookup()
-    doc_type_registry()
+    show_supported_doc_types()
+    show_doc_type_metadata()
+    show_pdf_download()
+    show_shelf_registration_parser()
+
+    # Doc type registry (all registered codes)
+    print("\n--- Full Doc Type Registry ---")
+    all_types = edinet_tools.doc_types()
+    print(f"{len(all_types)} document types registered:")
+    for dt in sorted(all_types, key=lambda t: t.code):
+        print(f"  {dt.code}: {dt.name_en} ({dt.name_jp})")
 
     if not has_api_key:
         print("\n" + "-" * 40)
@@ -173,6 +347,7 @@ def main():
             parse_large_holding(docs)
             parse_treasury_stock(docs)
             parse_securities_report(docs)
+            parse_internal_control(docs)
 
     print("\n" + "=" * 40)
     print("Getting Started:\n")
@@ -181,11 +356,17 @@ def main():
     print("  # Look up any company")
     print('  company = edinet_tools.entity("7203")')
     print(f"  # → {edinet_tools.entity('7203').name}\n")
+    print("  # Show all doc types with typed parsers")
+    print("  edinet_tools.supported_doc_types()")
+    print(f"  # → {edinet_tools.supported_doc_types()[:4]} ...\n")
+    print("  # Look up metadata for any doc type code")
+    print('  edinet_tools.doc_type("235")')
+    print("  # → DocType(code='235', name='Internal Control Report')\n")
     print("  # Get filings for a date")
     print('  docs = edinet_tools.documents("2026-01-20")\n')
     print("  # Parse → typed report object")
     print("  report = docs[0].parse()")
-    print("  # → SecuritiesReport, LargeHoldingReport, etc.\n")
+    print("  # → SecuritiesReport, LargeHoldingReport, InternalControlReport, etc.\n")
     print("  GitHub: https://github.com/matthelmer/edinet-tools")
 
 

--- a/edinet_tools/__init__.py
+++ b/edinet_tools/__init__.py
@@ -4,7 +4,7 @@ EDINET Tools - Python package for accessing Japanese corporate financial data.
 Python library for Japanese financial disclosure data.
 """
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 __author__ = "Matt Helmer"
 __description__ = "Python package for accessing Japanese corporate financial data from EDINET"
 
@@ -36,6 +36,7 @@ from .doc_types import DocType, doc_type, list_doc_types, doc_types
 # Parsers
 from .parsers import (
     parse,
+    supported_doc_types,
     ParsedReport,
     RawReport,
     LargeHoldingReport,
@@ -45,6 +46,10 @@ from .parsers import (
     ExtraordinaryReport,
     TreasuryStockReport,
     TenderOfferReport,
+    InternalControlReport,
+    ConfirmationReport,
+    ParentCompanyReport,
+    LargeHoldingChangeReport,
     GenericReport,  # Backwards compatibility alias
 )
 
@@ -75,6 +80,7 @@ __all__ = [
     "doc_types",
     # Parsers
     "parse",
+    "supported_doc_types",
     "ParsedReport",
     "RawReport",
     "LargeHoldingReport",
@@ -84,6 +90,10 @@ __all__ = [
     "ExtraordinaryReport",
     "TreasuryStockReport",
     "TenderOfferReport",
+    "InternalControlReport",
+    "ConfirmationReport",
+    "ParentCompanyReport",
+    "LargeHoldingChangeReport",
     # Legacy (deprecated)
     "EdinetClient",
     "EntityClassifier",

--- a/edinet_tools/api.py
+++ b/edinet_tools/api.py
@@ -104,12 +104,18 @@ def fetch_documents_list(date: Union[str, datetime.date],
     raise Exception("Failed to fetch documents after multiple retries.")
 
 
-def fetch_document(doc_id: str, max_retries: int = 3, delay_seconds: int = 5, api_key: str = None, timeout: int = 60) -> bytes:
+def fetch_document(doc_id: str, type: int = 5, max_retries: int = 3, delay_seconds: int = 5, api_key: str = None, timeout: int = 60) -> bytes:
     """
     Retrieve a specific document from EDINET API with retries and return raw bytes.
 
     Args:
         doc_id: EDINET document ID (e.g. 'S100ABC').
+        type: EDINET document type to retrieve (default 5):
+            1 = ZIP with HTML documents (PublicDoc, AuditDoc)
+            2 = PDF
+            3 = ZIP with attachments (AttachDoc)
+            4 = ZIP with English documents (EnglishDoc)
+            5 = XBRL to CSV (default, used by parsers)
         max_retries: Maximum number of retry attempts on failure.
         delay_seconds: Kept for backwards compatibility; retries now use
             exponential backoff (2s, 4s, 8s, ... capped at 30s).
@@ -118,7 +124,7 @@ def fetch_document(doc_id: str, max_retries: int = 3, delay_seconds: int = 5, ap
     """
     url = f'https://disclosure.edinet-fsa.go.jp/api/v2/documents/{doc_id}'
     params = {
-      "type": 5,  # '5' for CSV
+      "type": type,
       "Subscription-Key": api_key or EDINET_API_KEY,
     }
     query_string = urllib.parse.urlencode(params)

--- a/edinet_tools/doc_types.py
+++ b/edinet_tools/doc_types.py
@@ -2,7 +2,8 @@
 DocType registry for EDINET document types.
 
 Provides metadata about document types including English/Japanese names
-and descriptions.
+and descriptions. Every doc type code a user might encounter is registered
+here, even those without typed parsers.
 """
 from dataclasses import dataclass
 
@@ -27,9 +28,85 @@ class DocType:
         return f"DocType(code='{self.code}', name='{self.name_en}')"
 
 
-# Registry of known document types
+# Registry of all known EDINET document types.
+# Organized by family: securities notification/registration (010-110),
+# periodic reports (120-210), treasury/internal control (220-236),
+# tender offer (240-340), large shareholding (350-380).
 _DOC_TYPES: dict[str, DocType] = {
-    # Securities Reports (有価証券報告書)
+
+    # === Securities Notification (有価証券通知書) family (010-020) ===
+    "010": DocType(
+        code="010",
+        name_en="Securities Notification",
+        name_jp="有価証券通知書",
+        description="Notification for new securities issuance",
+    ),
+    "020": DocType(
+        code="020",
+        name_en="Securities Notification Amendment",
+        name_jp="有価証券通知書の訂正通知書",
+        description="Amendment to securities notification",
+    ),
+
+    # === Securities Registration Statement (有価証券届出書) family (030-050) ===
+    "030": DocType(
+        code="030",
+        name_en="Securities Registration Statement",
+        name_jp="有価証券届出書",
+        description="Registration statement for new securities issuance",
+    ),
+    "040": DocType(
+        code="040",
+        name_en="Securities Registration Statement Amendment",
+        name_jp="有価証券届出書の訂正届出書",
+        description="Amendment to securities registration statement",
+    ),
+    "050": DocType(
+        code="050",
+        name_en="Securities Registration Withdrawal",
+        name_jp="有価証券届出書の取下届出書",
+        description="Withdrawal of securities registration statement",
+    ),
+
+    # === Issuance Registration / Shelf Registration (発行登録書) family (060-110) ===
+    "060": DocType(
+        code="060",
+        name_en="Issuance Registration Notification",
+        name_jp="発行登録通知書",
+        description="Notification of issuance registration",
+    ),
+    "070": DocType(
+        code="070",
+        name_en="Shelf Registration",
+        name_jp="発行登録書",
+        description="Shelf registration for securities issuance",
+    ),
+    "080": DocType(
+        code="080",
+        name_en="Issuance Registration Statement",
+        name_jp="発行登録追補書類",
+        description="Supplementary document for issuance registration",
+    ),
+    "090": DocType(
+        code="090",
+        name_en="Issuance Registration Statement Amendment",
+        name_jp="発行登録書の訂正届出書",
+        description="Amendment to issuance registration statement",
+    ),
+    "100": DocType(
+        code="100",
+        name_en="Supplementary Issuance Registration Document",
+        name_jp="発行登録追補書類",
+        description="Supplementary document for shelf registration drawdown",
+    ),
+    "110": DocType(
+        code="110",
+        name_en="Issuance Registration Withdrawal",
+        name_jp="発行登録取下届出書",
+        description="Withdrawal of issuance registration",
+    ),
+
+    # === Periodic Reports (有価証券報告書 / 四半期報告書 etc.) family (120-210) ===
     "120": DocType(
         code="120",
         name_en="Securities Report",
@@ -42,13 +119,23 @@ _DOC_TYPES: dict[str, DocType] = {
         name_jp="有価証券報告書の訂正報告書",
         description="Amendment to annual securities report",
     ),
-
-    # Quarterly Reports (四半期報告書)
+    "135": DocType(
+        code="135",
+        name_en="Confirmation Document",
+        name_jp="確認書",
+        description="CEO/CFO confirmation document accompanying annual report",
+    ),
+    "136": DocType(
+        code="136",
+        name_en="Confirmation Document Amendment",
+        name_jp="確認書の訂正報告書",
+        description="Amendment to confirmation document",
+    ),
     "140": DocType(
         code="140",
         name_en="Quarterly Report",
         name_jp="四半期報告書",
-        description="Quarterly financial report (Q1, Q2, Q3)",
+        description="Quarterly financial report (Q1, Q2, Q3); abolished April 2024",
     ),
     "150": DocType(
         code="150",
@@ -56,8 +143,6 @@ _DOC_TYPES: dict[str, DocType] = {
         name_jp="四半期報告書の訂正報告書",
         description="Amendment to quarterly report",
     ),
-
-    # Semi-Annual Reports (半期報告書)
     "160": DocType(
         code="160",
         name_en="Semi-Annual Report",
@@ -70,8 +155,6 @@ _DOC_TYPES: dict[str, DocType] = {
         name_jp="半期報告書の訂正報告書",
         description="Amendment to semi-annual report",
     ),
-
-    # Extraordinary Reports (臨時報告書)
     "180": DocType(
         code="180",
         name_en="Extraordinary Report",
@@ -84,8 +167,20 @@ _DOC_TYPES: dict[str, DocType] = {
         name_jp="臨時報告書の訂正報告書",
         description="Amendment to extraordinary report",
     ),
+    "200": DocType(
+        code="200",
+        name_en="Parent Company Status Report",
+        name_jp="親会社等状況報告書",
+        description="Report on parent company status",
+    ),
+    "210": DocType(
+        code="210",
+        name_en="Parent Company Status Report Amendment",
+        name_jp="親会社等状況報告書の訂正報告書",
+        description="Amendment to parent company status report",
+    ),
 
-    # Treasury Stock Reports (自己株券買付状況報告書)
+    # === Treasury Stock / Internal Control (自己株 / 内部統制) family (220-236) ===
     "220": DocType(
         code="220",
         name_en="Treasury Stock Report",
@@ -98,8 +193,20 @@ _DOC_TYPES: dict[str, DocType] = {
         name_jp="自己株券買付状況報告書の訂正報告書",
         description="Amendment to treasury stock report",
     ),
+    "235": DocType(
+        code="235",
+        name_en="Internal Control Report",
+        name_jp="内部統制報告書",
+        description="Internal control report (J-SOX)",
+    ),
+    "236": DocType(
+        code="236",
+        name_en="Internal Control Report Amendment",
+        name_jp="内部統制報告書の訂正報告書",
+        description="Amendment to internal control report",
+    ),
 
-    # Tender Offer (公開買付)
+    # === Tender Offer (公開買付) family (240-340) ===
     "240": DocType(
         code="240",
         name_en="Tender Offer Registration",
@@ -124,8 +231,50 @@ _DOC_TYPES: dict[str, DocType] = {
         name_jp="公開買付報告書",
         description="Report on completion of tender offer",
     ),
+    "280": DocType(
+        code="280",
+        name_en="Tender Offer Report Amendment",
+        name_jp="公開買付報告書の訂正報告書",
+        description="Amendment to tender offer completion report",
+    ),
+    "290": DocType(
+        code="290",
+        name_en="Statement of Opinion Report",
+        name_jp="意見表明報告書",
+        description="Target company's statement of opinion on a tender offer",
+    ),
+    "300": DocType(
+        code="300",
+        name_en="Statement of Opinion Report Amendment",
+        name_jp="意見表明報告書の訂正報告書",
+        description="Amendment to statement of opinion report",
+    ),
+    "310": DocType(
+        code="310",
+        name_en="Response to Questions Report",
+        name_jp="対質問回答報告書",
+        description="Target company's response to acquirer's questions",
+    ),
+    "320": DocType(
+        code="320",
+        name_en="Response to Questions Report Amendment",
+        name_jp="対質問回答報告書の訂正報告書",
+        description="Amendment to response to questions report",
+    ),
+    "330": DocType(
+        code="330",
+        name_en="Exemption Application",
+        name_jp="別途買付け禁止の特例を受けるための申出書",
+        description="Application for exemption from separate purchase prohibition",
+    ),
+    "340": DocType(
+        code="340",
+        name_en="Exemption Application Amendment",
+        name_jp="別途買付け禁止の特例を受けるための申出書の訂正届出書",
+        description="Amendment to exemption application",
+    ),
 
-    # Large Shareholding Reports (大量保有報告書)
+    # === Large Shareholding Reports (大量保有報告書) family (350-380) ===
     "350": DocType(
         code="350",
         name_en="Large Shareholding Report",
@@ -148,43 +297,7 @@ _DOC_TYPES: dict[str, DocType] = {
         code="380",
         name_en="Large Shareholding Change Report Amendment",
         name_jp="変更報告書の訂正報告書",
-        description="Amendment to change report",
-    ),
-
-    # Securities Registration (有価証券届出書)
-    "030": DocType(
-        code="030",
-        name_en="Securities Registration",
-        name_jp="有価証券届出書",
-        description="Registration statement for new securities issuance",
-    ),
-    "040": DocType(
-        code="040",
-        name_en="Securities Registration Amendment",
-        name_jp="有価証券届出書の訂正届出書",
-        description="Amendment to securities registration statement",
-    ),
-
-    # Shelf Registration (発行登録書)
-    "070": DocType(
-        code="070",
-        name_en="Shelf Registration",
-        name_jp="発行登録書",
-        description="Shelf registration for securities issuance",
-    ),
-
-    # Securities Registration (有価証券届出書)
-    "010": DocType(
-        code="010",
-        name_en="Securities Registration",
-        name_jp="有価証券届出書",
-        description="Registration for new securities issuance",
-    ),
-    "020": DocType(
-        code="020",
-        name_en="Securities Registration Amendment",
-        name_jp="有価証券届出書の訂正届出書",
-        description="Amendment to securities registration",
+        description="Amendment to large shareholding change report",
     ),
 }
 

--- a/edinet_tools/parsers/__init__.py
+++ b/edinet_tools/parsers/__init__.py
@@ -12,6 +12,55 @@ from .semi_annual import SemiAnnualReport, parse_semi_annual_report
 from .extraordinary import ExtraordinaryReport, parse_extraordinary_report
 from .treasury_stock import TreasuryStockReport, parse_treasury_stock_report
 from .tender_offer import TenderOfferReport, parse_tender_offer
+from .tender_offer_report import TenderOfferResultReport, parse_tender_offer_report
+from .tender_offer_withdrawal import TenderOfferWithdrawalReport, parse_tender_offer_withdrawal
+from .opinion_report import OpinionReport, parse_opinion_report
+from .question_response import QuestionResponseReport, parse_question_response
+from .exemption_application import ExemptionApplicationReport, parse_exemption_application
+from .securities_notification import SecuritiesNotificationReport, parse_securities_notification
+from .securities_registration import SecuritiesRegistrationReport, parse_securities_registration
+from .securities_withdrawal import SecuritiesWithdrawalReport, parse_securities_withdrawal
+from .issuance_notification import IssuanceNotificationReport, parse_issuance_notification
+from .shelf_registration import ShelfRegistrationReport, parse_shelf_registration
+from .issuance_supplementary import IssuanceSupplementaryReport, parse_issuance_supplementary
+from .issuance_withdrawal import IssuanceWithdrawalReport, parse_issuance_withdrawal
+from .internal_control import InternalControlReport, parse_internal_control
+from .confirmation import ConfirmationReport, parse_confirmation
+from .parent_company import ParentCompanyReport, parse_parent_company
+from .large_holding_change import LargeHoldingChangeReport, parse_large_holding_change
+
+
+# Doc type codes that have typed parsers (not raw fallback).
+# Kept as a frozenset so supported_doc_types() can return it without
+# rebuilding a function-reference dict at module load time.
+_SUPPORTED_CODES: frozenset[str] = frozenset({
+    # === Securities notification / registration family (010-110) ===
+    "010", "020",           # Securities notification
+    "030", "040", "050",   # Securities registration
+    "060",                 # Issuance notification
+    "070", "080", "090",   # Shelf registration
+    "100",                 # Issuance supplementary
+    "110",                 # Issuance withdrawal
+    # === Securities reports family (120-170) ===
+    "120", "130",          # Securities report + amendment
+    "135", "136",          # Confirmation document + amendment
+    "140", "150",          # Quarterly report + amendment
+    "160", "170",          # Semi-annual report + amendment
+    # === Extraordinary / treasury / internal control / tender offer family (180-340) ===
+    "180", "190",          # Extraordinary report + amendment
+    "200", "210",          # Parent company status report + amendment
+    "220", "230",          # Treasury stock + amendment
+    "235", "236",          # Internal control report + amendment
+    "240", "250",          # Tender offer registration + amendment
+    "260",                 # Tender offer withdrawal
+    "270", "280",          # Tender offer report + amendment
+    "290", "300",          # Opinion report + amendment
+    "310", "320",          # Question response + amendment
+    "330", "340",          # Exemption application + amendment
+    # === Large shareholding family (350-380) ===
+    "350", "360",          # Large shareholding + amendment
+    "370", "380",          # Large shareholding change + amendment
+})
 
 
 def parse(document) -> ParsedReport:
@@ -26,15 +75,57 @@ def parse(document) -> ParsedReport:
         ParsedReport subclass appropriate for the document type
     """
     parsers = {
+        # === Securities notification / registration family (010-110) ===
+        "010": parse_securities_notification,
+        "020": parse_securities_notification,  # Amendment
+        "030": parse_securities_registration,
+        "040": parse_securities_registration,  # Amendment
+        "050": parse_securities_withdrawal,
+        "060": parse_issuance_notification,
+        # Doc 070 is also a shelf registration filing (発行登録書) — same family as 080.
+        # Route it to the shelf registration parser pending separate XBRL inspection.
+        "070": parse_shelf_registration,
+        "080": parse_shelf_registration,
+        "090": parse_shelf_registration,       # Amendment
+        "100": parse_issuance_supplementary,
+        "110": parse_issuance_withdrawal,
+
+        # === Securities reports family (120-170) ===
         "120": parse_securities_report,
+        "130": parse_securities_report,        # Amendment
+        "135": parse_confirmation,
+        "136": parse_confirmation,             # Amendment
         "140": parse_quarterly_report,
+        "150": parse_quarterly_report,         # Amendment
         "160": parse_semi_annual_report,
+        "170": parse_semi_annual_report,       # Amendment
+
+        # === Extraordinary / treasury / tender offer family (180-340) ===
         "180": parse_extraordinary_report,
+        "190": parse_extraordinary_report,     # Amendment
+        "200": parse_parent_company,
+        "210": parse_parent_company,           # Amendment
         "220": parse_treasury_stock_report,
-        "230": parse_treasury_stock_report,  # Amendments use same parser
+        "230": parse_treasury_stock_report,    # Amendment (existing)
+        "235": parse_internal_control,
+        "236": parse_internal_control,         # Amendment
         "240": parse_tender_offer,
-        "250": parse_tender_offer,  # Amendments use same parser
+        "250": parse_tender_offer,             # Amendment
+        "260": parse_tender_offer_withdrawal,
+        "270": parse_tender_offer_report,
+        "280": parse_tender_offer_report,      # Amendment
+        "290": parse_opinion_report,
+        "300": parse_opinion_report,           # Amendment
+        "310": parse_question_response,
+        "320": parse_question_response,        # Amendment
+        "330": parse_exemption_application,
+        "340": parse_exemption_application,    # Amendment
+
+        # === Large shareholding family (350-380) ===
         "350": parse_large_holding,
+        "360": parse_large_holding,            # Amendment
+        "370": parse_large_holding_change,
+        "380": parse_large_holding_change,     # Amendment
     }
 
     parser = parsers.get(document.doc_type_code)
@@ -44,8 +135,14 @@ def parse(document) -> ParsedReport:
     return parse_raw(document)
 
 
+def supported_doc_types() -> list[str]:
+    """Return doc type codes that have typed parsers (not raw fallback)."""
+    return sorted(_SUPPORTED_CODES)
+
+
 __all__ = [
     'parse',
+    'supported_doc_types',
     'ParsedReport',
     'RawReport',
     'LargeHoldingReport',
@@ -55,6 +152,22 @@ __all__ = [
     'ExtraordinaryReport',
     'TreasuryStockReport',
     'TenderOfferReport',
+    'TenderOfferResultReport',
+    'TenderOfferWithdrawalReport',
+    'OpinionReport',
+    'QuestionResponseReport',
+    'ExemptionApplicationReport',
+    'SecuritiesNotificationReport',
+    'SecuritiesRegistrationReport',
+    'SecuritiesWithdrawalReport',
+    'IssuanceNotificationReport',
+    'ShelfRegistrationReport',
+    'IssuanceSupplementaryReport',
+    'IssuanceWithdrawalReport',
+    'InternalControlReport',
+    'ConfirmationReport',
+    'ParentCompanyReport',
+    'LargeHoldingChangeReport',
     # Backwards compatibility
     'GenericReport',
 ]

--- a/edinet_tools/parsers/confirmation.py
+++ b/edinet_tools/parsers/confirmation.py
@@ -1,0 +1,116 @@
+"""
+Parser for Confirmation Document filings (Doc Types 135/136).
+
+確認書 — CEO/CFO attestation documents accompanying annual securities reports.
+These certify that the securities report content is accurate and complete,
+as required under the Financial Instruments and Exchange Act.
+
+Doc 135: Confirmation document (確認書)
+Doc 136: Confirmation document amendment (確認書の訂正報告書)
+
+Note: Most confirmation documents are PDF-only (csvFlag='0' in the EDINET
+filing index). Use ``fetch_document(doc_id, type=2)`` to retrieve the PDF
+content. This parser handles any XBRL-enabled filings for completeness.
+"""
+from dataclasses import dataclass
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Enrich this map after inspecting real Doc 135 filings.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class ConfirmationReport(ParsedReport):
+    """
+    Parsed Confirmation Document filing (Doc 135/136).
+
+    CEO/CFO attestation accompanying annual securities reports.
+    Most filings are PDF-only — use raw_fields and text_blocks to explore
+    available XBRL elements in any XBRL-enabled filings before extending
+    this parser.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        amended = ' [AMENDED]' if self.is_amendment else ''
+        return f"ConfirmationReport(filer='{name}'{amended})"
+
+
+def parse_confirmation(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> ConfirmationReport:
+    """
+    Parse a Confirmation Document filing (Doc 135/136).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        ConfirmationReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return ConfirmationReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return ConfirmationReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/exemption_application.py
+++ b/edinet_tools/parsers/exemption_application.py
@@ -1,0 +1,124 @@
+"""
+Parser for Exemption Application filings (Doc Type 330/340).
+
+Extracts data from 買付け等の制限の免除申請書 filings. These are filed when
+a party seeks regulatory exemption from the prohibition on separate
+purchases during a tender offer period. The FSA must approve the
+exemption before the purchases can proceed.
+
+Doc 330: Original exemption application
+Doc 340: Amendment to exemption application
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Domain-specific elements can be added once real Doc 330/340 filings
+# have been inspected for their XBRL element names.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class ExemptionApplicationReport(ParsedReport):
+    """
+    Parsed Exemption Application filing (Doc 330/340).
+
+    Filed when a party seeks exemption from the separate purchase
+    prohibition during a tender offer period. No confirmed filings exist
+    in the database as of 2026-03, but the doc type is part of the
+    standard EDINET tender offer family (240-340).
+
+    Key fields:
+        filer_name: Name of the entity applying for the exemption
+        filer_edinet_code: EDINET code of the applicant
+        security_code: Securities code of the target company
+        is_amendment: Whether this is an amendment (Doc 340)
+
+    Use raw_fields and text_blocks to explore available XBRL elements
+    in real filings before extending this parser with domain-specific fields.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"ExemptionApplicationReport(filer='{name}'{amend})"
+
+
+def parse_exemption_application(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> ExemptionApplicationReport:
+    """
+    Parse an Exemption Application filing (Doc 330/340).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        ExemptionApplicationReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return ExemptionApplicationReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return ExemptionApplicationReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/internal_control.py
+++ b/edinet_tools/parsers/internal_control.py
@@ -1,0 +1,215 @@
+"""
+Parser for Internal Control Report filings (Doc Type 235/236).
+
+Extracts internal control evaluation data from 内部統制報告書 filings.
+These are filed annually by listed companies reporting on the effectiveness
+of their internal controls over financial reporting (J-SOX compliance).
+The key field is the evaluation result — whether internal controls are
+effective or material weaknesses were found.
+
+Doc 235: Original internal control report
+Doc 236: Amendment to internal control report
+"""
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+    parse_date,
+)
+
+
+# XBRL Element ID mappings for Doc 235/236
+# Namespace: jpctl_cor (Japanese Internal Control)
+ELEMENT_MAP = {
+    # === DEI Elements ===
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+
+    # === Cover Page (jpctl_cor namespace) ===
+    'company_name': 'jpctl_cor:CompanyNameCoverPage',
+    'company_name_en': 'jpctl_cor:CompanyNameInEnglishCoverPage',
+    'filing_date': 'jpctl_cor:FilingDateCoverPage',
+    'document_title': 'jpctl_cor:DocumentTitleCoverPage',
+    'clause_of_stipulation': 'jpctl_cor:ClauseOfStipulationCoverPage',
+    'representative': 'jpctl_cor:TitleAndNameOfRepresentativeCoverPage',
+    'cfo': 'jpctl_cor:TitleAndNameOfChiefFinancialOfficerCoverPage',
+    'address': 'jpctl_cor:AddressOfRegisteredHeadquarterCoverPage',
+    'place_of_filing': 'jpctl_cor:PlaceOfFilingCoverPage',
+
+    # === Key TextBlock Elements ===
+    # These are captured automatically by categorize_elements but also mapped
+    # here for direct access on the dataclass.
+    'evaluation_result_text': 'jpctl_cor:ResultOfEvaluationTextBlock',
+    'scope_and_procedures_text': 'jpctl_cor:ScopeDateAndProceduresForEvaluationTextBlock',
+    'framework_text': 'jpctl_cor:BasicFrameworkOfInternalControlRelatedToFinancialReportingTextBlock',
+    'special_attention_text': 'jpctl_cor:OtherInformationForSpecialAttentionTextBlock',
+    'supplementary_info_text': 'jpctl_cor:SupplementaryInformationTextBlock',
+}
+
+
+@dataclass
+class InternalControlReport(ParsedReport):
+    """
+    Parsed Internal Control Report (Doc 235/236).
+
+    Filed annually by listed companies under J-SOX (金融商品取引法 Section 24-4-4)
+    to report on the effectiveness of internal controls over financial reporting.
+    The board's evaluation result is the critical output — it discloses whether
+    controls are effective or whether material weaknesses exist.
+
+    Key fields:
+        company_name: Name of the reporting company (Japanese)
+        company_name_en: Name of the reporting company (English)
+        filer_edinet_code: EDINET code of the filing entity
+        filing_date: Date the report was filed
+        representative: Title and name of the representative who signed
+        cfo: Title and name of the CFO who signed
+        clause_of_stipulation: Legal clause reference (e.g. Article 24-4-4)
+        evaluation_result_text: THE KEY FIELD — board's evaluation of effectiveness
+        scope_and_procedures_text: Scope, date, and procedures used in evaluation
+        framework_text: Internal control framework description
+        special_attention_text: Matters requiring special attention
+        supplementary_info_text: Supplementary disclosures
+        is_amendment: Whether this is an amendment (Doc 236)
+    """
+
+    # Filer identification
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+
+    # Cover page
+    company_name: str | None = None
+    company_name_en: str | None = None
+    filing_date: date | None = None
+    document_title: str | None = None
+    clause_of_stipulation: str | None = None
+    representative: str | None = None
+    cfo: str | None = None
+    address: str | None = None
+    place_of_filing: str | None = None
+
+    # Key text blocks (Japanese text)
+    evaluation_result_text: str | None = None
+    scope_and_procedures_text: str | None = None
+    framework_text: str | None = None
+    special_attention_text: str | None = None
+    supplementary_info_text: str | None = None
+
+    # Amendment
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.company_name or self.filer_name or 'Unknown'
+        if len(name) > 25:
+            name = name[:22] + '...'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"InternalControlReport(filer='{name}'{amend})"
+
+
+def parse_internal_control(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> InternalControlReport:
+    """
+    Parse an Internal Control Report filing (Doc 235/236).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        InternalControlReport with extracted fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return InternalControlReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    # DEI elements
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    # Cover page
+    company_name = get('company_name') or filer_name
+    company_name_en = get('company_name_en') or filer_name_en
+    filing_date = parse_date(get('filing_date'))
+    document_title = get('document_title')
+    clause_of_stipulation = get('clause_of_stipulation')
+    representative = get('representative')
+    cfo = get('cfo')
+    address = get('address')
+    place_of_filing = get('place_of_filing')
+
+    # Key text blocks
+    evaluation_result_text = get('evaluation_result_text')
+    scope_and_procedures_text = get('scope_and_procedures_text')
+    framework_text = get('framework_text')
+    special_attention_text = get('special_attention_text')
+    supplementary_info_text = get('supplementary_info_text')
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return InternalControlReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+
+        # Filer identification
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+
+        # Cover page
+        company_name=company_name,
+        company_name_en=company_name_en,
+        filing_date=filing_date,
+        document_title=document_title,
+        clause_of_stipulation=clause_of_stipulation,
+        representative=representative,
+        cfo=cfo,
+        address=address,
+        place_of_filing=place_of_filing,
+
+        # Key text blocks
+        evaluation_result_text=evaluation_result_text,
+        scope_and_procedures_text=scope_and_procedures_text,
+        framework_text=framework_text,
+        special_attention_text=special_attention_text,
+        supplementary_info_text=supplementary_info_text,
+
+        # Amendment
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/issuance_notification.py
+++ b/edinet_tools/parsers/issuance_notification.py
@@ -1,0 +1,109 @@
+"""
+Parser for Issuance Notification filings (Doc Type 060).
+
+Minimal parser for 発行登録追補書類 (shelf registration supplementary/pricing
+supplement) filings. Maps common DEI fields; additional fields can be added
+once real filings have been inspected for their XBRL element names.
+
+Doc 060: Issuance notification (pricing supplement under a shelf registration)
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Enrich this map after inspecting real Doc 060 filings.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class IssuanceNotificationReport(ParsedReport):
+    """
+    Parsed Issuance Notification filing (Doc 060).
+
+    Minimal structured report. Use raw_fields and text_blocks to explore
+    available XBRL elements in real filings before extending this parser.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        return f"IssuanceNotificationReport(filer='{name}')"
+
+
+def parse_issuance_notification(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> IssuanceNotificationReport:
+    """
+    Parse an Issuance Notification filing.
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        IssuanceNotificationReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return IssuanceNotificationReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return IssuanceNotificationReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/issuance_supplementary.py
+++ b/edinet_tools/parsers/issuance_supplementary.py
@@ -1,0 +1,221 @@
+"""
+Parser for Issuance Supplementary filings (Doc Type 100).
+
+Extracts shelf registration supplement details from 発行登録追補書類 filings.
+These are filed to supplement a shelf registration with the specific terms
+of each actual issuance under the shelf. Key data includes the supplement
+number, parent shelf registration number, planned amounts, and remaining
+balance available under the shelf.
+
+Doc 100: Issuance supplementary document
+"""
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+    parse_date,
+)
+
+
+# XBRL Element ID mappings for Doc 100
+# Namespace: jpcrp_cor (same family as shelf_registration 080/090)
+ELEMENT_MAP = {
+    # === DEI Elements ===
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+
+    # === Cover Page (jpcrp_cor namespace) ===
+    'company_name': 'jpcrp_cor:CompanyNameCoverPage',
+    'company_name_en': 'jpcrp_cor:CompanyNameInEnglishCoverPage',
+    'filing_date': 'jpcrp_cor:FilingDateCoverPage',
+    'document_title': 'jpcrp_cor:DocumentTitleCoverPage',
+
+    # === Supplement / Shelf registration linkage ===
+    'supplement_number': 'jpcrp_cor:ShelfRegistrationSupplementNumberCoverPage',
+    'parent_shelf_reg_number': 'jpcrp_cor:ShelfRegistrationNumberContentsOfShelfRegistrationStatementCoverPage',
+    'parent_filing_date': 'jpcrp_cor:FilingDateContentsOfShelfRegistrationStatementCoverPage',
+    'effective_date': 'jpcrp_cor:EffectiveDateContentsOfShelfRegistrationStatementCoverPage',
+    'end_of_issue_period': 'jpcrp_cor:EndOfPeriodOfIssueContentsOfShelfRegistrationStatementCoverPage',
+    'planned_amount': 'jpcrp_cor:PlannedAmountOfIssueOrLimitOnOutstandingBalanceContentsOfShelfRegistrationStatementCoverPage',
+    'remaining_balance': 'jpcrp_cor:RemainingBalanceCoverPage',
+    'security_types': 'jpcrp_cor:TypesOfSecuritiesToShelfRegisterForOfferingOrDistributionCoverPage',
+
+    # === Filer / representative details ===
+    'address': 'jpcrp_cor:AddressOfRegisteredHeadquarterCoverPage',
+    'representative': 'jpcrp_cor:TitleAndNameOfRepresentativeCoverPage',
+    'place_of_filing': 'jpcrp_cor:PlaceOfFilingCoverPage',
+}
+
+
+@dataclass
+class IssuanceSupplementaryReport(ParsedReport):
+    """
+    Parsed Issuance Supplementary filing (Doc 100).
+
+    Filed to supplement a shelf registration (発行登録追補書類) with the
+    specific terms of each actual issuance. Links back to the parent shelf
+    registration and discloses the amounts issued and remaining balance.
+
+    Key fields:
+        company_name: Name of the issuing company (Japanese)
+        company_name_en: Name of the issuing company (English)
+        filer_edinet_code: EDINET code of the filing entity
+        filing_date: Date this supplement was filed
+        supplement_number: Sequential number of this supplement under the shelf
+        parent_shelf_reg_number: Registration number of the parent shelf filing
+        planned_amount: Amount planned for issuance under this supplement
+        remaining_balance: Remaining balance available under the shelf registration
+        security_types: Types of securities being issued
+        is_amendment: Whether this is an amendment
+    """
+
+    # Filer identification
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+
+    # Cover page
+    company_name: str | None = None
+    company_name_en: str | None = None
+    filing_date: date | None = None
+    document_title: str | None = None
+
+    # Supplement / shelf linkage
+    supplement_number: str | None = None
+    parent_shelf_reg_number: str | None = None
+    parent_filing_date: date | None = None
+    effective_date: str | None = None
+    end_of_issue_period: str | None = None
+    planned_amount: str | None = None
+    remaining_balance: str | None = None
+    security_types: str | None = None
+
+    # Filer / representative details
+    address: str | None = None
+    representative: str | None = None
+    place_of_filing: str | None = None
+
+    # Amendment
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.company_name or self.filer_name or 'Unknown'
+        if len(name) > 25:
+            name = name[:22] + '...'
+        supp = self.supplement_number or '?'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"IssuanceSupplementaryReport(filer='{name}', supplement='{supp}'{amend})"
+
+
+def parse_issuance_supplementary(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> IssuanceSupplementaryReport:
+    """
+    Parse an Issuance Supplementary filing.
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        IssuanceSupplementaryReport with extracted fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return IssuanceSupplementaryReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    # DEI elements
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    # Cover page
+    company_name = get('company_name') or filer_name
+    company_name_en = get('company_name_en') or filer_name_en
+    filing_date = parse_date(get('filing_date'))
+    document_title = get('document_title')
+
+    # Supplement / shelf linkage
+    supplement_number = get('supplement_number')
+    parent_shelf_reg_number = get('parent_shelf_reg_number')
+    parent_filing_date = parse_date(get('parent_filing_date'))
+    effective_date = get('effective_date')
+    end_of_issue_period = get('end_of_issue_period')
+    planned_amount = get('planned_amount')
+    remaining_balance = get('remaining_balance')
+    security_types = get('security_types')
+
+    # Filer / representative details
+    address = get('address')
+    representative = get('representative')
+    place_of_filing = get('place_of_filing')
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return IssuanceSupplementaryReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+
+        # Filer identification
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+
+        # Cover page
+        company_name=company_name,
+        company_name_en=company_name_en,
+        filing_date=filing_date,
+        document_title=document_title,
+
+        # Supplement / shelf linkage
+        supplement_number=supplement_number,
+        parent_shelf_reg_number=parent_shelf_reg_number,
+        parent_filing_date=parent_filing_date,
+        effective_date=effective_date,
+        end_of_issue_period=end_of_issue_period,
+        planned_amount=planned_amount,
+        remaining_balance=remaining_balance,
+        security_types=security_types,
+
+        # Filer / representative details
+        address=address,
+        representative=representative,
+        place_of_filing=place_of_filing,
+
+        # Amendment
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/issuance_withdrawal.py
+++ b/edinet_tools/parsers/issuance_withdrawal.py
@@ -1,0 +1,109 @@
+"""
+Parser for Issuance Withdrawal filings (Doc Type 110).
+
+Minimal parser for 発行登録取下書 (shelf registration withdrawal) filings.
+Maps common DEI fields; additional fields can be added once real filings
+have been inspected for their XBRL element names.
+
+Doc 110: Issuance withdrawal document
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Enrich this map after inspecting real Doc 110 filings.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class IssuanceWithdrawalReport(ParsedReport):
+    """
+    Parsed Issuance Withdrawal filing (Doc 110).
+
+    Minimal structured report. Use raw_fields and text_blocks to explore
+    available XBRL elements in real filings before extending this parser.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        return f"IssuanceWithdrawalReport(filer='{name}')"
+
+
+def parse_issuance_withdrawal(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> IssuanceWithdrawalReport:
+    """
+    Parse an Issuance Withdrawal filing.
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        IssuanceWithdrawalReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return IssuanceWithdrawalReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return IssuanceWithdrawalReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/large_holding_change.py
+++ b/edinet_tools/parsers/large_holding_change.py
@@ -1,0 +1,117 @@
+"""
+Parser for Large Shareholding Change Report filings (Doc Types 370/380).
+
+変更報告書 — filed when a holder of 5%+ of a company's shares changes their
+position by 1% or more (or when certain other material changes occur in their
+holding status), as required under the Financial Instruments and Exchange Act.
+
+Doc 370: Large shareholding change report (変更報告書)
+Doc 380: Large shareholding change report amendment (変更報告書の訂正報告書)
+
+Note: In practice, change reports (変更報告書) appear to file under doc type
+350, not 370. Zero filings have been observed for doc type 370 in the EDINET
+API. This parser exists for completeness — if a 370 filing ever appears, it
+will be captured with typed routing rather than falling to parse_raw.
+"""
+from dataclasses import dataclass
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Enrich this map after inspecting real Doc 370 filings if they emerge.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class LargeHoldingChangeReport(ParsedReport):
+    """
+    Parsed Large Shareholding Change Report filing (Doc 370/380).
+
+    Filed when a 5%+ shareholder's position changes by 1% or more.
+    In practice, change reports appear to route through doc type 350 rather
+    than 370. Use raw_fields and text_blocks to explore any XBRL elements
+    if a real filing is ever encountered.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        amended = ' [AMENDED]' if self.is_amendment else ''
+        return f"LargeHoldingChangeReport(filer='{name}'{amended})"
+
+
+def parse_large_holding_change(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> LargeHoldingChangeReport:
+    """
+    Parse a Large Shareholding Change Report filing (Doc 370/380).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        LargeHoldingChangeReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return LargeHoldingChangeReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return LargeHoldingChangeReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/opinion_report.py
+++ b/edinet_tools/parsers/opinion_report.py
@@ -1,0 +1,200 @@
+"""
+Parser for Statement of Opinion Report filings (Doc Type 290/300).
+
+Extracts data from 意見表明報告書 filings. These are filed by the target
+company's board in response to a tender offer, disclosing the board's
+opinion (support, oppose, or neutral) and the rationale.
+
+Doc 290: Original statement of opinion report
+Doc 300: Amendment to statement of opinion report
+"""
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+    parse_date,
+)
+
+
+# XBRL Element ID mappings for Doc 290/300
+# Namespace: jptoo-pst_cor (Japanese Public Tender Offer — Position Statement)
+ELEMENT_MAP = {
+    # === DEI Elements ===
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+
+    # === Cover Page (jptoo-pst_cor namespace) ===
+    'document_title': 'jptoo-pst_cor:DocumentTitleCoverPage',
+    'filing_date': 'jptoo-pst_cor:FilingDateCoverPage',
+    'target_company_name': 'jptoo-pst_cor:NameOfFilerCoverPage',
+    'target_company_address': 'jptoo-pst_cor:LocationOfFilerCoverPage',
+
+    # === Key TextBlock Elements ===
+    # The acquirer and opinion are the two most important fields.
+    'acquirer_info_text': 'jptoo-pst_cor:NameAndResidentialAddressOrLocationOfTenderOfferorTextBlock',
+    'opinion_text': 'jptoo-pst_cor:OpinionAndBasisAndReasonOfOpinionRegardingSaidTenderOfferTextBlock',
+    'share_classes_text': 'jptoo-pst_cor:ClassesOfShareCertificatesEtcForTenderOfferorToAcquireByPurchaseEtcTextBlock',
+    'officer_holdings_text': 'jptoo-pst_cor:NumberOfShareCertificatesEtcAndNumberOfVotingRightsOwnedByOfficersTextBlock',
+    'extension_request_text': 'jptoo-pst_cor:RequestForExtendingTenderOfferPeriodNA',
+    'inquiries_text': 'jptoo-pst_cor:InquiriesToTenderOfferorNA',
+    'profit_provision_text': 'jptoo-pst_cor:DescriptionOfProvisionOfProfitByTenderOfferorOrItsSpecialInterestPartiesNA',
+    'defense_policy_text': 'jptoo-pst_cor:PolicyToAddressBasicPolicyAboutHowToControlCompanyNA',
+}
+
+
+@dataclass
+class OpinionReport(ParsedReport):
+    """
+    Parsed Statement of Opinion Report (Doc 290/300).
+
+    Filed by the target company's board in response to a tender offer.
+    The board discloses whether it supports, opposes, or is neutral on
+    the offer and provides the reasoning.
+
+    Key fields:
+        target_company_name: Name of the target company filing the opinion
+        filer_edinet_code: EDINET code of the target company
+        security_code: Securities code of the target company
+        filing_date: Date the opinion was filed
+        opinion_text: THE KEY FIELD — the board's actual opinion and rationale
+        acquirer_info_text: Name and address of the acquirer (tender offeror)
+        share_classes_text: Classes of shares the tender offer covers
+        officer_holdings_text: Shares and voting rights owned by officers
+        defense_policy_text: Poison pill / takeover defense policy disclosure
+        is_amendment: Whether this is an amendment (Doc 300)
+    """
+
+    # Filer identification
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+
+    # Cover page
+    filing_date: date | None = None
+    document_title: str | None = None
+    target_company_name: str | None = None
+    target_company_address: str | None = None
+
+    # Key text blocks (Japanese text)
+    acquirer_info_text: str | None = None
+    opinion_text: str | None = None
+    share_classes_text: str | None = None
+    officer_holdings_text: str | None = None
+    extension_request_text: str | None = None
+    inquiries_text: str | None = None
+    profit_provision_text: str | None = None
+    defense_policy_text: str | None = None
+
+    # Amendment
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.target_company_name or self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"OpinionReport(filer='{name}'{amend})"
+
+
+def parse_opinion_report(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> OpinionReport:
+    """
+    Parse a Statement of Opinion Report filing (Doc 290/300).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        OpinionReport with extracted fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return OpinionReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    # DEI elements
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    # Cover page
+    filing_date = parse_date(get('filing_date'))
+    document_title = get('document_title')
+    target_company_name = get('target_company_name') or filer_name
+    target_company_address = get('target_company_address')
+
+    # Key text blocks
+    acquirer_info_text = get('acquirer_info_text')
+    opinion_text = get('opinion_text')
+    share_classes_text = get('share_classes_text')
+    officer_holdings_text = get('officer_holdings_text')
+    extension_request_text = get('extension_request_text')
+    inquiries_text = get('inquiries_text')
+    profit_provision_text = get('profit_provision_text')
+    defense_policy_text = get('defense_policy_text')
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return OpinionReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+
+        # Filer identification
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+
+        # Cover page
+        filing_date=filing_date,
+        document_title=document_title,
+        target_company_name=target_company_name,
+        target_company_address=target_company_address,
+
+        # Key text blocks
+        acquirer_info_text=acquirer_info_text,
+        opinion_text=opinion_text,
+        share_classes_text=share_classes_text,
+        officer_holdings_text=officer_holdings_text,
+        extension_request_text=extension_request_text,
+        inquiries_text=inquiries_text,
+        profit_provision_text=profit_provision_text,
+        defense_policy_text=defense_policy_text,
+
+        # Amendment
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/parent_company.py
+++ b/edinet_tools/parsers/parent_company.py
@@ -1,0 +1,121 @@
+"""
+Parser for Parent Company Status Report filings (Doc Types 200/210).
+
+親会社等状況報告書 — reports on parent-subsidiary relationships filed by
+listed subsidiaries to disclose material information about their parent
+companies or controlling entities, as required under the Financial
+Instruments and Exchange Act.
+
+Doc 200: Parent company status report (親会社等状況報告書)
+Doc 210: Parent company status report amendment (親会社等状況報告書の訂正報告書)
+
+Note: Parent company status reports appear to be primarily PDF-only
+(csvFlag='0'). Use ``fetch_document(doc_id, type=2)`` to retrieve the PDF
+content. These filings can be relevant for MBO screening — a listed subsidiary
+disclosing its parent's intentions may signal privatisation risk or squeeze-out.
+"""
+from dataclasses import dataclass
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Enrich this map after inspecting real Doc 200 filings.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class ParentCompanyReport(ParsedReport):
+    """
+    Parsed Parent Company Status Report filing (Doc 200/210).
+
+    Reports on parent-subsidiary relationships for listed subsidiaries.
+    Most filings are PDF-only — use raw_fields and text_blocks to explore
+    available XBRL elements in any XBRL-enabled filings before extending
+    this parser.
+
+    Relevant for MBO screening: a listed subsidiary disclosing its parent's
+    material changes may signal privatisation risk or squeeze-out.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        amended = ' [AMENDED]' if self.is_amendment else ''
+        return f"ParentCompanyReport(filer='{name}'{amended})"
+
+
+def parse_parent_company(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> ParentCompanyReport:
+    """
+    Parse a Parent Company Status Report filing (Doc 200/210).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        ParentCompanyReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return ParentCompanyReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return ParentCompanyReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/question_response.py
+++ b/edinet_tools/parsers/question_response.py
@@ -1,0 +1,122 @@
+"""
+Parser for Response to Questions Report filings (Doc Type 310/320).
+
+Extracts data from 質問状に対する回答書 filings. These are filed by the
+target company in response to questions raised during a tender offer
+process — typically from a hostile bidder or concerned shareholders.
+
+Doc 310: Original response to questions report
+Doc 320: Amendment to response to questions report
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Domain-specific elements can be added once real Doc 310/320 filings
+# have been inspected for their XBRL element names.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class QuestionResponseReport(ParsedReport):
+    """
+    Parsed Response to Questions Report (Doc 310/320).
+
+    Filed by the target company in response to questions raised during
+    a tender offer process. Rare filing type — only one confirmed filing
+    in the database as of 2026-03.
+
+    Key fields:
+        filer_name: Name of the company filing the response
+        filer_edinet_code: EDINET code of the filing company
+        security_code: Securities code of the filing company
+        is_amendment: Whether this is an amendment (Doc 320)
+
+    Use raw_fields and text_blocks to explore available XBRL elements
+    in real filings before extending this parser with domain-specific fields.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"QuestionResponseReport(filer='{name}'{amend})"
+
+
+def parse_question_response(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> QuestionResponseReport:
+    """
+    Parse a Response to Questions Report filing (Doc 310/320).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        QuestionResponseReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return QuestionResponseReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return QuestionResponseReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/securities_notification.py
+++ b/edinet_tools/parsers/securities_notification.py
@@ -1,0 +1,112 @@
+"""
+Parser for Securities Notification filings (Doc Type 010/020).
+
+Minimal parser for 有価証券通知書 (securities notification) filings.
+These are early-stage notifications before a full securities registration.
+Maps common DEI fields; additional fields can be added once real filings
+have been inspected for their XBRL element names.
+
+Doc 010: Securities notification
+Doc 020: Amendment to securities notification
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Enrich this map after inspecting real Doc 010/020 filings.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class SecuritiesNotificationReport(ParsedReport):
+    """
+    Parsed Securities Notification filing (Doc 010/020).
+
+    Minimal structured report. Use raw_fields and text_blocks to explore
+    available XBRL elements in real filings before extending this parser.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"SecuritiesNotificationReport(filer='{name}'{amend})"
+
+
+def parse_securities_notification(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> SecuritiesNotificationReport:
+    """
+    Parse a Securities Notification filing.
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        SecuritiesNotificationReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return SecuritiesNotificationReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return SecuritiesNotificationReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/securities_registration.py
+++ b/edinet_tools/parsers/securities_registration.py
@@ -1,0 +1,327 @@
+"""
+Parser for Securities Registration Statement filings (Doc Type 030/040).
+
+Extracts registration details from 有価証券届出書 filings. These are primarily
+investment trust and fund registration filings containing detailed fund structure,
+operational info, and DEI metadata.
+
+Doc 030: Original securities registration statement
+Doc 040: Amendment to securities registration statement
+"""
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+    parse_date,
+)
+
+
+# XBRL Element ID mappings for Doc 030/040
+# These filings are primarily investment trust registrations using the
+# jpsps_cor (investment trust) namespace alongside the standard jpdei_cor DEI fields.
+ELEMENT_MAP = {
+    # === DEI Elements (common across all filing types) ===
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+
+    # === Investment Trust Cover Page (jpsps_cor namespace) ===
+    'document_title': 'jpsps_cor:DocumentTitleCoverPage',
+    'filing_date': 'jpsps_cor:FilingDateCoverPage',
+    'issuer_name': 'jpsps_cor:IssuerNameCoverPage',
+    'address': 'jpsps_cor:AddressOfRegisteredHeadquarterCoverPage',
+    'representative': 'jpsps_cor:TitleAndNameOfRepresentativeCoverPage',
+    'contact_person': 'jpsps_cor:NameOfContactPersonCoverPage',
+    'telephone_number': 'jpsps_cor:TelephoneNumberCoverPage',
+    'place_of_filing': 'jpsps_cor:PlaceOfFilingCoverPage',
+    # Amount and name of trust certificates to be registered — stored as TextBlock
+    # but mapped here for discoverability via extract_value.
+    'amount_to_register': 'jpsps_cor:AmountOfDomesticInvestmentTrustBeneficiaryCertificateToRegisterForOfferingOrDistributionCoverPageTextBlock',
+    'fund_name_for_registration': 'jpsps_cor:NameOfFundRelatedToDomesticInvestmentTrustBeneficiaryCertificateToRegisterForOfferingOrDistributionCoverPageTextBlock',
+
+    # === Fund Identity (TextBlock — mapped for discoverability) ===
+    'fund_name': 'jpsps_cor:FundNameTextBlock',
+    'fund_purpose': 'jpsps_cor:PurposesAndBasicFeaturesOfFundTextBlock',
+    'fund_scheme': 'jpsps_cor:FundSchemeTextBlock',
+    'fund_history': 'jpsps_cor:FundHistoryTextBlock',
+
+    # === Investment Policy (TextBlock) ===
+    'investment_policy': 'jpsps_cor:InvestmentPolicyTextBlock',
+    'investment_risks': 'jpsps_cor:InvestmentRisksTextBlock',
+    'eligible_investments': 'jpsps_cor:ThingsToInvestInTextBlock',
+    'investment_restrictions': 'jpsps_cor:RestrictionsOnInvestmentTextBlock',
+
+    # === Operations (TextBlock) ===
+    'management_fees': 'jpsps_cor:ManagementFeesAndChargesTextBlock',
+    'application_fee': 'jpsps_cor:ApplicationFeeSecurityInformationTextBlock',
+    'application_period': 'jpsps_cor:ApplicationPeriodSecurityInformationTextBlock',
+    'application_unit': 'jpsps_cor:ApplicationUnitSecurityInformationTextBlock',
+    'redemption_procedures': 'jpsps_cor:RedemptionProceduresEtcTextBlock',
+    'profit_distribution_policy': 'jpsps_cor:ProfitDistributionPolicyTextBlock',
+    'taxation': 'jpsps_cor:TaxationTextBlock',
+
+    # === Financial Information (TextBlock) ===
+    'financial_info': 'jpsps_cor:FinancialInformationOfFundTextBlock',
+    'balance_sheet': 'jpsps_cor:BalanceSheetTextBlock',
+    'income_statement': 'jpsps_cor:StatementOfIncomeAndRetainedEarningsTextBlock',
+    'changes_in_net_assets': 'jpsps_cor:ChangesInNetAssetsTextBlock',
+    'net_assets_calculation': 'jpsps_cor:CalculationOfNetAssetsTextBlock',
+}
+
+
+@dataclass
+class SecuritiesRegistrationReport(ParsedReport):
+    """
+    Parsed Securities Registration Statement (Doc 030/040).
+
+    These filings are primarily investment trust and fund registrations
+    (有価証券届出書). They contain DEI metadata and, for investment trusts,
+    detailed fund-specific fields under the jpsps_cor namespace.
+
+    Key fields:
+        filer_name: Name of the filing entity (Japanese)
+        filer_edinet_code: EDINET code of the filing entity
+        filing_date: Date the registration was filed
+        fund_name: Name of the investment trust fund (if applicable)
+        issuer_name: Name of the fund management company
+        contact_person: Name of the contact person at the issuer
+        telephone_number: Telephone number of the contact
+        place_of_filing: Place where the filing was submitted
+        amount_to_register: Amount/units of trust certificates being registered (text)
+        fund_name_for_registration: Fund name as stated on the cover registration block (text)
+        fund_purpose: Fund purpose and basic features (TextBlock)
+        fund_scheme: Fund structure description (TextBlock)
+        fund_history: Fund history (TextBlock)
+        investment_policy: Investment policy (TextBlock)
+        investment_risks: Risk disclosure (TextBlock)
+        eligible_investments: Eligible investments description (TextBlock)
+        investment_restrictions: Investment restrictions (TextBlock)
+        management_fees: Management fees and charges (TextBlock)
+        application_fee: Application fee details (TextBlock)
+        application_period: Application period (TextBlock)
+        application_unit: Minimum application unit (TextBlock)
+        redemption_procedures: Redemption procedure details (TextBlock)
+        profit_distribution_policy: Distribution policy (TextBlock)
+        taxation: Taxation details (TextBlock)
+        financial_info: Financial information summary (TextBlock)
+        balance_sheet: Balance sheet (TextBlock)
+        income_statement: Income and retained earnings statement (TextBlock)
+        changes_in_net_assets: Changes in net assets (TextBlock)
+        net_assets_calculation: Net assets calculation (TextBlock)
+        is_amendment: Whether this is an amendment (Doc 040)
+    """
+
+    # Filer identification
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+
+    # Cover page — structured fields
+    filing_date: date | None = None
+    document_title: str | None = None
+    issuer_name: str | None = None
+    address: str | None = None
+    representative: str | None = None
+    contact_person: str | None = None
+    telephone_number: str | None = None
+    place_of_filing: str | None = None
+
+    # Cover page — registration block (stored as TextBlock in XBRL but key identity info)
+    amount_to_register: str | None = None
+    fund_name_for_registration: str | None = None
+
+    # Fund identity (TextBlock fields — content is HTML/text from XBRL)
+    fund_name: str | None = None
+    fund_purpose: str | None = None
+    fund_scheme: str | None = None
+    fund_history: str | None = None
+
+    # Investment policy (TextBlock)
+    investment_policy: str | None = None
+    investment_risks: str | None = None
+    eligible_investments: str | None = None
+    investment_restrictions: str | None = None
+
+    # Operations (TextBlock)
+    management_fees: str | None = None
+    application_fee: str | None = None
+    application_period: str | None = None
+    application_unit: str | None = None
+    redemption_procedures: str | None = None
+    profit_distribution_policy: str | None = None
+    taxation: str | None = None
+
+    # Financial information (TextBlock)
+    financial_info: str | None = None
+    balance_sheet: str | None = None
+    income_statement: str | None = None
+    changes_in_net_assets: str | None = None
+    net_assets_calculation: str | None = None
+
+    # Amendment
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.fund_name or self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"SecuritiesRegistrationReport(filer='{name}'{amend})"
+
+
+def parse_securities_registration(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> SecuritiesRegistrationReport:
+    """
+    Parse a Securities Registration Statement filing.
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        SecuritiesRegistrationReport with extracted fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return SecuritiesRegistrationReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    # DEI elements
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+
+    # Cover page — structured fields
+    document_title = get('document_title')
+    filing_date = parse_date(get('filing_date'))
+    issuer_name = get('issuer_name') or filer_name
+    address = get('address')
+    representative = get('representative')
+    contact_person = get('contact_person')
+    telephone_number = get('telephone_number')
+    place_of_filing = get('place_of_filing')
+
+    # Cover page — registration block (TextBlock elements used as identity info)
+    amount_to_register = get('amount_to_register')
+    fund_name_for_registration = get('fund_name_for_registration')
+
+    # Fund identity (TextBlock)
+    fund_name = get('fund_name')
+    fund_purpose = get('fund_purpose')
+    fund_scheme = get('fund_scheme')
+    fund_history = get('fund_history')
+
+    # Investment policy (TextBlock)
+    investment_policy = get('investment_policy')
+    investment_risks = get('investment_risks')
+    eligible_investments = get('eligible_investments')
+    investment_restrictions = get('investment_restrictions')
+
+    # Operations (TextBlock)
+    management_fees = get('management_fees')
+    application_fee = get('application_fee')
+    application_period = get('application_period')
+    application_unit = get('application_unit')
+    redemption_procedures = get('redemption_procedures')
+    profit_distribution_policy = get('profit_distribution_policy')
+    taxation = get('taxation')
+
+    # Financial information (TextBlock)
+    financial_info = get('financial_info')
+    balance_sheet = get('balance_sheet')
+    income_statement = get('income_statement')
+    changes_in_net_assets = get('changes_in_net_assets')
+    net_assets_calculation = get('net_assets_calculation')
+
+    # Amendment detection
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    # Categorize all elements
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return SecuritiesRegistrationReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+
+        # Filer identification
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+
+        # Cover page — structured
+        filing_date=filing_date,
+        document_title=document_title,
+        issuer_name=issuer_name,
+        address=address,
+        representative=representative,
+        contact_person=contact_person,
+        telephone_number=telephone_number,
+        place_of_filing=place_of_filing,
+
+        # Cover page — registration block
+        amount_to_register=amount_to_register,
+        fund_name_for_registration=fund_name_for_registration,
+
+        # Fund identity
+        fund_name=fund_name,
+        fund_purpose=fund_purpose,
+        fund_scheme=fund_scheme,
+        fund_history=fund_history,
+
+        # Investment policy
+        investment_policy=investment_policy,
+        investment_risks=investment_risks,
+        eligible_investments=eligible_investments,
+        investment_restrictions=investment_restrictions,
+
+        # Operations
+        management_fees=management_fees,
+        application_fee=application_fee,
+        application_period=application_period,
+        application_unit=application_unit,
+        redemption_procedures=redemption_procedures,
+        profit_distribution_policy=profit_distribution_policy,
+        taxation=taxation,
+
+        # Financial information
+        financial_info=financial_info,
+        balance_sheet=balance_sheet,
+        income_statement=income_statement,
+        changes_in_net_assets=changes_in_net_assets,
+        net_assets_calculation=net_assets_calculation,
+
+        # Amendment
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/securities_withdrawal.py
+++ b/edinet_tools/parsers/securities_withdrawal.py
@@ -1,0 +1,109 @@
+"""
+Parser for Securities Withdrawal filings (Doc Type 050).
+
+Minimal parser for 有価証券届出書の取下書 (securities registration withdrawal)
+filings. Maps common DEI fields; additional fields can be added once real
+filings have been inspected for their XBRL element names.
+
+Doc 050: Securities withdrawal document
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Enrich this map after inspecting real Doc 050 filings.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class SecuritiesWithdrawalReport(ParsedReport):
+    """
+    Parsed Securities Withdrawal filing (Doc 050).
+
+    Minimal structured report. Use raw_fields and text_blocks to explore
+    available XBRL elements in real filings before extending this parser.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        return f"SecuritiesWithdrawalReport(filer='{name}')"
+
+
+def parse_securities_withdrawal(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> SecuritiesWithdrawalReport:
+    """
+    Parse a Securities Withdrawal filing.
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        SecuritiesWithdrawalReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return SecuritiesWithdrawalReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return SecuritiesWithdrawalReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/shelf_registration.py
+++ b/edinet_tools/parsers/shelf_registration.py
@@ -1,0 +1,185 @@
+"""
+Parser for Shelf Registration Statement filings (Doc Type 080/090).
+
+Extracts shelf registration details from 発行登録書（株券、社債券等）filings.
+These are filed when a company registers a shelf of securities it may issue
+over a future period. Key data includes the planned issuance period, security
+types to be shelf-registered, and identifying information.
+
+Doc 080: Original shelf registration statement
+Doc 090: Amendment to shelf registration statement
+"""
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+    parse_date,
+)
+
+
+# XBRL Element ID mappings for Doc 080/090
+ELEMENT_MAP = {
+    # === Cover Page (jpcrp_cor namespace) ===
+    'company_name': 'jpcrp_cor:CompanyNameCoverPage',
+    'company_name_en': 'jpcrp_cor:CompanyNameInEnglishCoverPage',
+    'filing_date': 'jpcrp_cor:FilingDateCoverPage',
+    'document_title': 'jpcrp_cor:DocumentTitleCoverPage',
+    'shelf_registration_number': 'jpcrp_cor:ShelfRegistrationNumberCoverPage',
+    'planned_period': 'jpcrp_cor:PlannedPeriodOfIssueCoverPage',
+    'security_types': 'jpcrp_cor:TypesOfSecuritiesToShelfRegisterForOfferingOrDistributionCoverPage',
+    'place_of_filing': 'jpcrp_cor:PlaceOfFilingCoverPage',
+    'address': 'jpcrp_cor:AddressOfRegisteredHeadquarterCoverPage',
+    'representative': 'jpcrp_cor:TitleAndNameOfRepresentativeCoverPage',
+
+    # === DEI Elements (jpdei_cor namespace) ===
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class ShelfRegistrationReport(ParsedReport):
+    """
+    Parsed Shelf Registration Statement (Doc 080/090).
+
+    These filings disclose a company's shelf registration of securities
+    (発行登録書) that it plans to issue over a defined future period.
+    The shelf registration number identifies the specific registration.
+
+    Key fields:
+        company_name: Name of the issuing company (Japanese)
+        company_name_en: Name of the issuing company (English)
+        filer_edinet_code: EDINET code of the filing entity
+        filing_date: Date the shelf registration was filed
+        shelf_registration_number: Unique registration identifier
+        planned_period: Planned issuance period (Japanese text)
+        security_types: Types of securities to be registered
+        is_amendment: Whether this is an amendment (Doc 090)
+    """
+
+    # Filer identification
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+
+    # Cover page
+    company_name: str | None = None
+    company_name_en: str | None = None
+    filing_date: date | None = None
+    document_title: str | None = None
+    shelf_registration_number: str | None = None
+    planned_period: str | None = None
+    security_types: str | None = None
+    place_of_filing: str | None = None
+    address: str | None = None
+    representative: str | None = None
+
+    # Amendment
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.company_name or self.filer_name or 'Unknown'
+        if len(name) > 25:
+            name = name[:22] + '...'
+        reg = self.shelf_registration_number or '?'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"ShelfRegistrationReport(filer='{name}', reg='{reg}'{amend})"
+
+
+def parse_shelf_registration(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> ShelfRegistrationReport:
+    """
+    Parse a Shelf Registration Statement filing.
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        ShelfRegistrationReport with extracted fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return ShelfRegistrationReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    # DEI elements
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+
+    # Cover page elements
+    company_name = get('company_name') or filer_name
+    company_name_en = get('company_name_en') or filer_name_en
+    filing_date = parse_date(get('filing_date'))
+    document_title = get('document_title')
+    shelf_registration_number = get('shelf_registration_number')
+    planned_period = get('planned_period')
+    security_types = get('security_types')
+    place_of_filing = get('place_of_filing')
+    address = get('address')
+    representative = get('representative')
+
+    # Amendment detection
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    # Categorize all elements
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return ShelfRegistrationReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+
+        # Filer identification
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+
+        # Cover page
+        company_name=company_name,
+        company_name_en=company_name_en,
+        filing_date=filing_date,
+        document_title=document_title,
+        shelf_registration_number=shelf_registration_number,
+        planned_period=planned_period,
+        security_types=security_types,
+        place_of_filing=place_of_filing,
+        address=address,
+        representative=representative,
+
+        # Amendment
+        is_amendment=is_amendment,
+    )

--- a/edinet_tools/parsers/tender_offer_report.py
+++ b/edinet_tools/parsers/tender_offer_report.py
@@ -1,0 +1,228 @@
+"""
+Parser for Tender Offer Report filings (Doc Type 270/280).
+
+Extracts completion report data from 公開買付報告書 filings.
+These are filed by the acquirer after a tender offer closes, reporting
+the actual results — shares purchased, final ownership ratios, etc.
+
+Doc 270: Original tender offer report
+Doc 280: Amendment to tender offer report
+"""
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+    parse_date,
+    parse_int,
+    parse_percentage,
+)
+
+
+# XBRL Element ID mappings for Doc 270/280
+# Namespace: jptoo-tor_cor (Japanese Public Tender Offer Report)
+ELEMENT_MAP = {
+    # === DEI Elements ===
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+
+    # === Cover Page ===
+    'document_title': 'jptoo-tor_cor:DocumentTitleCoverPage',
+    'filing_date': 'jptoo-tor_cor:FilingDateCoverPage',
+    'acquirer_name': 'jptoo-tor_cor:FullNameOrNameOfFilerCoverPage',
+    'acquirer_address': 'jptoo-tor_cor:ResidentialAddressOrLocationOfFilerCoverPage',
+    'contact_phone': 'jptoo-tor_cor:TelephoneNumberCoverPage',
+    'contact_name': 'jptoo-tor_cor:NameOfContactPersonCoverPage',
+
+    # === Ownership / Voting Rights (post-purchase results) ===
+    'voting_rights_purchased': 'jptoo-tor_cor:NumberOfVotingRightsRepresentedByShareCertificatesEtcAcquiredByPurchaseEtcTextBlock',
+    'voting_rights_owned_by_offeror': 'jptoo-tor_cor:NumberOfVotingRightsRepresentedByShareCertificatesEtcOwnedByTenderOfferorAsOfFilingDateA',
+    'voting_rights_special_interest': 'jptoo-tor_cor:NumberNumberOfVotingRightsRepresentedByShareCertificatesEtcOwnedBySpecialInterestPartiesG',
+    'total_voting_rights': 'jptoo-tor_cor:NumberNumberOfVotingRightsOwnedByAllShareholdersEtcOfSubjectCompanyJ',
+    'purchase_ratio': 'jptoo-tor_cor:RatioOfNumberOfVotingRightsRepresentedByShareCertificatesEtcPurchasedAmongNumberOfVotingRightsOwnedByAllShareholdersEtcOfSubjectCompany',
+    'holding_ratio_after': 'jptoo-tor_cor:HoldingRatioOfShareCertificatesEtcAfterPurchaseEtc',
+
+    # === Key TextBlock Elements ===
+    'target_name': 'jptoo-tor_cor:NameOfSubjectCompanyTextBlock',
+    'share_classes_text': 'jptoo-tor_cor:ClassesOfShareCertificatesEtcRelatedToPurchaseEtcTextBlock',
+    'shares_acquired_text': 'jptoo-tor_cor:NumberOfShareCertificatesEtcAcquiredByPurchaseEtcTextBlock',
+    'result_text': 'jptoo-tor_cor:SuccessOrFailureOfTenderOfferTextBlock',
+    'period_text': 'jptoo-tor_cor:TenderOfferPeriodTextBlock',
+    'announcement_text': 'jptoo-tor_cor:DateOfOfficialAnnouncementOfTenderOfferAndNameOfNewspaperContainingItTextBlock',
+    'settlement_date_text': 'jptoo-tor_cor:DateOfCommencementOfSettlementTextBlock',
+}
+
+
+@dataclass
+class TenderOfferResultReport(ParsedReport):
+    """
+    Parsed Tender Offer Report (Doc 270/280).
+
+    These filings report the outcome of a completed tender offer (TOB /
+    公開買付). The acquirer discloses how many shares were purchased, the
+    actual ownership ratio achieved, and settlement details.
+
+    Key fields:
+        acquirer_name: Name of the entity that made the tender offer
+        target_name: Name of the target company
+        filing_date: Date the report was filed
+        voting_rights_purchased: Voting rights represented by shares purchased
+        purchase_ratio: Actual ratio of voting rights purchased to total
+        holding_ratio_after: Final ownership ratio after purchase
+        is_amendment: Whether this is an amendment (Doc 280)
+        result_text: Narrative description of the tender offer result
+    """
+
+    # Acquirer identification
+    acquirer_name: str | None = None
+    acquirer_name_en: str | None = None
+    acquirer_edinet_code: str | None = None
+    acquirer_address: str | None = None
+
+    # Cover page
+    filing_date: date | None = None
+    contact_name: str | None = None
+    contact_phone: str | None = None
+
+    # Target
+    target_name: str | None = None
+
+    # Ownership / voting rights (actual results)
+    voting_rights_purchased: int | None = None
+    voting_rights_owned_by_offeror: int | None = None
+    voting_rights_special_interest: int | None = None
+    total_voting_rights: int | None = None
+    purchase_ratio: Decimal | None = None
+    holding_ratio_after: Decimal | None = None
+
+    # Amendment
+    is_amendment: bool = False
+
+    # Key text blocks (Japanese text)
+    share_classes_text: str | None = None
+    shares_acquired_text: str | None = None
+    result_text: str | None = None
+    period_text: str | None = None
+    announcement_text: str | None = None
+    settlement_date_text: str | None = None
+
+    def __repr__(self) -> str:
+        name = self.acquirer_name or 'Unknown'
+        if len(name) > 25:
+            name = name[:22] + '...'
+        target = self.target_name or '?'
+        if len(target) > 25:
+            target = target[:22] + '...'
+        amend = ' [AMENDED]' if self.is_amendment else ''
+        return f"TenderOfferResultReport(acquirer='{name}', target='{target}'{amend})"
+
+
+def parse_tender_offer_report(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> TenderOfferResultReport:
+    """
+    Parse a Tender Offer Report filing (Doc 270/280).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        TenderOfferResultReport with extracted fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return TenderOfferResultReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    # DEI elements
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+
+    # Acquirer name from cover page (preferred) or DEI fallback
+    acquirer_name = get('acquirer_name') or filer_name
+    acquirer_address = get('acquirer_address')
+    filing_date = parse_date(get('filing_date'))
+    contact_name = get('contact_name')
+    contact_phone = get('contact_phone')
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    # Target and results
+    target_name = get('target_name')
+    share_classes_text = get('share_classes_text')
+    shares_acquired_text = get('shares_acquired_text')
+    voting_rights_purchased = parse_int(get('voting_rights_purchased'))
+    voting_rights_owned_by_offeror = parse_int(get('voting_rights_owned_by_offeror'))
+    voting_rights_special_interest = parse_int(get('voting_rights_special_interest'))
+    total_voting_rights = parse_int(get('total_voting_rights'))
+    purchase_ratio = parse_percentage(get('purchase_ratio'))
+    holding_ratio_after = parse_percentage(get('holding_ratio_after'))
+    result_text = get('result_text')
+    period_text = get('period_text')
+    announcement_text = get('announcement_text')
+    settlement_date_text = get('settlement_date_text')
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return TenderOfferResultReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+
+        acquirer_name=acquirer_name or getattr(document, 'filer_name', None),
+        acquirer_name_en=filer_name_en,
+        acquirer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None),
+        acquirer_address=acquirer_address,
+
+        filing_date=filing_date,
+        contact_name=contact_name,
+        contact_phone=contact_phone,
+
+        target_name=target_name,
+
+        share_classes_text=share_classes_text,
+        shares_acquired_text=shares_acquired_text,
+        voting_rights_purchased=voting_rights_purchased,
+        voting_rights_owned_by_offeror=voting_rights_owned_by_offeror,
+        voting_rights_special_interest=voting_rights_special_interest,
+        total_voting_rights=total_voting_rights,
+        purchase_ratio=purchase_ratio,
+        holding_ratio_after=holding_ratio_after,
+
+        is_amendment=is_amendment,
+
+        result_text=result_text,
+        period_text=period_text,
+        announcement_text=announcement_text,
+        settlement_date_text=settlement_date_text,
+    )

--- a/edinet_tools/parsers/tender_offer_withdrawal.py
+++ b/edinet_tools/parsers/tender_offer_withdrawal.py
@@ -1,0 +1,120 @@
+"""
+Parser for Tender Offer Withdrawal filings (Doc Type 260).
+
+Extracts data from 公開買付撤回届出書 filings. These are filed when an
+acquirer withdraws a previously announced tender offer before it closes.
+Withdrawals require regulatory approval and disclosure of the reason.
+
+Doc 260: Tender offer withdrawal notification
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import ParsedReport
+from .extraction import (
+    extract_csv_from_zip,
+    extract_value,
+    categorize_elements,
+)
+
+
+# Common DEI elements available across all filing types.
+# Domain-specific elements (jptoo-twn_cor namespace) can be added once
+# real Doc 260 filings have been inspected for their XBRL element names.
+ELEMENT_MAP = {
+    'filer_name': 'jpdei_cor:FilerNameInJapaneseDEI',
+    'filer_name_en': 'jpdei_cor:FilerNameInEnglishDEI',
+    'filer_edinet_code': 'jpdei_cor:EDINETCodeDEI',
+    'security_code': 'jpdei_cor:SecurityCodeDEI',
+    'amendment_flag': 'jpdei_cor:AmendmentFlagDEI',
+}
+
+
+@dataclass
+class TenderOfferWithdrawalReport(ParsedReport):
+    """
+    Parsed Tender Offer Withdrawal filing (Doc 260).
+
+    Filed when an acquirer withdraws a tender offer. No confirmed filings
+    exist in the database as of 2026-03, but the doc type is part of the
+    standard EDINET tender offer family (240-340).
+
+    Key fields:
+        filer_name: Name of the acquirer withdrawing the offer
+        filer_edinet_code: EDINET code of the acquirer
+        security_code: Securities code of the target company
+        is_amendment: Always False for Doc 260 (no amendment type exists)
+
+    Use raw_fields and text_blocks to explore available XBRL elements
+    in real filings before extending this parser with domain-specific fields.
+    """
+
+    filer_name: str | None = None
+    filer_name_en: str | None = None
+    filer_edinet_code: str | None = None
+    security_code: str | None = None
+    is_amendment: bool = False
+
+    def __repr__(self) -> str:
+        name = self.filer_name or 'Unknown'
+        if len(name) > 30:
+            name = name[:27] + '...'
+        return f"TenderOfferWithdrawalReport(filer='{name}')"
+
+
+def parse_tender_offer_withdrawal(document=None, *, csv_files=None, doc_id=None, doc_type_code=None) -> TenderOfferWithdrawalReport:
+    """
+    Parse a Tender Offer Withdrawal filing (Doc 260).
+
+    Args:
+        document: Document object with fetch() method (optional if csv_files provided)
+        csv_files: Pre-extracted CSV data (list of dicts with 'filename' and 'data' keys)
+        doc_id: Document ID (required if csv_files provided)
+        doc_type_code: Document type code (required if csv_files provided)
+
+    Returns:
+        TenderOfferWithdrawalReport with extracted DEI fields
+    """
+    if csv_files is None:
+        zip_bytes = document.fetch()
+        csv_files = extract_csv_from_zip(zip_bytes)
+        doc_id = document.doc_id
+        doc_type_code = document.doc_type_code
+
+    if not csv_files:
+        return TenderOfferWithdrawalReport(
+            doc_id=doc_id,
+            doc_type_code=doc_type_code,
+            source_files=[],
+            raw_fields={},
+            unmapped_fields={},
+            text_blocks={},
+        )
+
+    source_files = [f['filename'] for f in csv_files]
+
+    def get(key: str, context: list[str] | None = None) -> str | None:
+        return extract_value(csv_files, ELEMENT_MAP.get(key, ''), context_patterns=context)
+
+    filer_edinet_code = get('filer_edinet_code', ['FilingDateInstant'])
+    filer_name = get('filer_name', ['FilingDateInstant'])
+    filer_name_en = get('filer_name_en', ['FilingDateInstant'])
+    security_code = get('security_code', ['FilingDateInstant'])
+    amendment_flag = get('amendment_flag', ['FilingDateInstant'])
+    is_amendment = amendment_flag == 'true' if amendment_flag else False
+
+    raw_fields, text_blocks, unmapped_fields = categorize_elements(csv_files, ELEMENT_MAP)
+
+    return TenderOfferWithdrawalReport(
+        doc_id=doc_id,
+        doc_type_code=doc_type_code,
+        source_files=source_files,
+        raw_fields=raw_fields,
+        unmapped_fields=unmapped_fields,
+        text_blocks=text_blocks,
+        filer_name=filer_name,
+        filer_name_en=filer_name_en,
+        filer_edinet_code=filer_edinet_code or getattr(document, 'filer_edinet_code', None) if document else filer_edinet_code,
+        security_code=security_code,
+        is_amendment=is_amendment,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "edinet-tools"
-version = "0.4.3"
+version = "0.5.0"
 authors = [
     {name = "Matt Helmer"},
 ]

--- a/tests/test_amendment_routing.py
+++ b/tests/test_amendment_routing.py
@@ -1,0 +1,44 @@
+"""Tests that amendment doc types route to the correct base parser."""
+import pytest
+from unittest.mock import MagicMock
+from edinet_tools.parsers import parse
+from edinet_tools.parsers.generic import RawReport
+
+
+AMENDMENT_ROUTES = [
+    ("130", "120"),  # Securities Report Amendment -> Securities Report
+    ("150", "140"),  # Quarterly Report Amendment -> Quarterly Report
+    ("170", "160"),  # Semi-Annual Report Amendment -> Semi-Annual Report
+    ("190", "180"),  # Extraordinary Report Amendment -> Extraordinary Report
+    ("360", "350"),  # Large Shareholding Amendment -> Large Shareholding Report
+]
+
+
+@pytest.mark.parametrize("amendment_code,base_code", AMENDMENT_ROUTES)
+def test_amendment_does_not_fall_through_to_raw(amendment_code, base_code):
+    """Amendment doc types should NOT fall through to RawReport/parse_raw."""
+    doc = MagicMock()
+    doc.doc_type_code = amendment_code
+    doc.doc_id = f"TEST_{amendment_code}"
+    doc.fetch.return_value = None
+
+    try:
+        result = parse(doc)
+        assert not isinstance(result, RawReport), \
+            f"Doc type {amendment_code} fell through to RawReport instead of routing to base parser"
+    except Exception:
+        pass  # Parser attempted but failed on mock data = correct routing
+
+
+def test_existing_amendment_routes_still_work():
+    """Verify pre-existing amendment routes (230, 250) are unchanged."""
+    for code in ["230", "250"]:
+        doc = MagicMock()
+        doc.doc_type_code = code
+        doc.doc_id = f"TEST_{code}"
+        doc.fetch.return_value = None
+        try:
+            result = parse(doc)
+            assert not isinstance(result, RawReport)
+        except Exception:
+            pass

--- a/tests/test_internal_control.py
+++ b/tests/test_internal_control.py
@@ -1,0 +1,322 @@
+"""
+Tests for InternalControlReport parser (Doc 235/236).
+
+Covers field-level extraction from mock XBRL CSV data, amendment detection,
+text block capture, and the parse() router.
+"""
+import io
+import zipfile
+import pytest
+from datetime import date
+from unittest.mock import Mock
+
+from edinet_tools.parsers import parse
+from edinet_tools.parsers.internal_control import (
+    InternalControlReport,
+    parse_internal_control,
+    ELEMENT_MAP,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_csv_row(element_id: str, context_id: str, value: str) -> str:
+    """Return one tab-separated CSV line in EDINET format (9 columns)."""
+    return f"{element_id}\tlabel\t{context_id}\t0\t連結\t期間\t\t\t{value}"
+
+
+def _make_zip(rows: list[str]) -> bytes:
+    """Wrap CSV rows into a UTF-16LE encoded ZIP as EDINET produces."""
+    content = '\n'.join(rows)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('XBRL_TO_CSV/test.csv', content.encode('utf-16le'))
+    return buf.getvalue()
+
+
+def _make_doc(doc_id: str = 'S100TEST', doc_type: str = '235', rows: list[str] | None = None) -> Mock:
+    doc = Mock()
+    doc.doc_id = doc_id
+    doc.doc_type_code = doc_type
+    doc.filer_name = ''
+    doc.filer_edinet_code = ''
+    doc.fetch.return_value = _make_zip(rows) if rows is not None else b''
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+class TestInternalControlRouting:
+    """parse() must route doc 235/236 to InternalControlReport."""
+
+    def test_doc_235_routes_to_internal_control(self):
+        doc = _make_doc(doc_type='235')
+        result = parse(doc)
+        assert isinstance(result, InternalControlReport)
+
+    def test_doc_236_routes_to_internal_control(self):
+        doc = _make_doc(doc_type='236')
+        result = parse(doc)
+        assert isinstance(result, InternalControlReport)
+
+
+# ---------------------------------------------------------------------------
+# Empty-document behaviour
+# ---------------------------------------------------------------------------
+
+class TestEmptyDocument:
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_doc(rows=None)
+        report = parse_internal_control(doc)
+        assert isinstance(report, InternalControlReport)
+        assert report.doc_id == 'S100TEST'
+        assert report.company_name is None
+        assert report.filing_date is None
+        assert report.is_amendment is False
+        assert report.source_files == []
+
+
+# ---------------------------------------------------------------------------
+# Field-level extraction from mock CSV
+# ---------------------------------------------------------------------------
+
+class TestFieldExtraction:
+    """Prove that ELEMENT_MAP keys correctly map to dataclass fields."""
+
+    def test_extracts_company_name(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['company_name'], 'FilingDateInstant', 'テスト株式会社'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.company_name == 'テスト株式会社'
+
+    def test_extracts_filing_date(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['filing_date'], 'FilingDateInstant', '2025-06-20'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.filing_date == date(2025, 6, 20)
+
+    def test_extracts_representative(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['representative'], 'FilingDateInstant', '代表取締役社長 山田 太郎'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.representative == '代表取締役社長 山田 太郎'
+
+    def test_extracts_cfo(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['cfo'], 'FilingDateInstant', '取締役CFO 田中 花子'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.cfo == '取締役CFO 田中 花子'
+
+    def test_extracts_filer_edinet_code(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['filer_edinet_code'], 'FilingDateInstant', 'E01234'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.filer_edinet_code == 'E01234'
+
+    def test_extracts_security_code(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['security_code'], 'FilingDateInstant', '4321'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.security_code == '4321'
+
+    def test_company_name_falls_back_to_filer_name(self):
+        """When company_name is absent, company_name falls back to DEI filer_name."""
+        rows = [
+            _make_csv_row(ELEMENT_MAP['filer_name'], 'FilingDateInstant', 'DEI Filer Corp'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        # company_name should fall back to filer_name
+        assert report.company_name == 'DEI Filer Corp'
+        assert report.filer_name == 'DEI Filer Corp'
+
+    def test_all_cover_page_fields_extracted_together(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['company_name'], 'FilingDateInstant', 'サンプル株式会社'),
+            _make_csv_row(ELEMENT_MAP['filing_date'], 'FilingDateInstant', '2025-06-30'),
+            _make_csv_row(ELEMENT_MAP['representative'], 'FilingDateInstant', '代表取締役 佐藤 一郎'),
+            _make_csv_row(ELEMENT_MAP['cfo'], 'FilingDateInstant', 'CFO 鈴木 次郎'),
+            _make_csv_row(ELEMENT_MAP['filer_edinet_code'], 'FilingDateInstant', 'E09999'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.company_name == 'サンプル株式会社'
+        assert report.filing_date == date(2025, 6, 30)
+        assert report.representative == '代表取締役 佐藤 一郎'
+        assert report.cfo == 'CFO 鈴木 次郎'
+        assert report.filer_edinet_code == 'E09999'
+
+
+# ---------------------------------------------------------------------------
+# Text block capture
+# ---------------------------------------------------------------------------
+
+class TestTextBlockCapture:
+    """ResultOfEvaluationTextBlock and others must land in text_blocks."""
+
+    def test_evaluation_result_text_block_captured(self):
+        rows = [
+            _make_csv_row(
+                ELEMENT_MAP['evaluation_result_text'],
+                'FilingDateInstant',
+                '当社の内部統制は有効であると評価した。',
+            ),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        # Should be captured in the structured field
+        assert report.evaluation_result_text == '当社の内部統制は有効であると評価した。'
+        # Must also appear in text_blocks (categorize_elements picks up TextBlocks)
+        assert 'ResultOfEvaluationTextBlock' in report.text_blocks
+
+    def test_scope_and_procedures_text_block_captured(self):
+        rows = [
+            _make_csv_row(
+                ELEMENT_MAP['scope_and_procedures_text'],
+                'FilingDateInstant',
+                '評価の範囲、基準日及び評価手続きについて...',
+            ),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert 'ScopeDateAndProceduresForEvaluationTextBlock' in report.text_blocks
+
+    def test_unmapped_text_block_still_captured(self):
+        """Any TextBlock element is captured even if not in ELEMENT_MAP."""
+        rows = [
+            _make_csv_row(
+                'jpctl_cor:SomeOtherTextBlock',
+                'FilingDateInstant',
+                'その他の情報。',
+            ),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert 'SomeOtherTextBlock' in report.text_blocks
+
+
+# ---------------------------------------------------------------------------
+# Amendment detection
+# ---------------------------------------------------------------------------
+
+class TestAmendmentDetection:
+    def test_amendment_flag_true(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['amendment_flag'], 'FilingDateInstant', 'true'),
+        ]
+        doc = _make_doc(doc_type='236', rows=rows)
+        report = parse_internal_control(doc)
+        assert report.is_amendment is True
+
+    def test_amendment_flag_false(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['amendment_flag'], 'FilingDateInstant', 'false'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.is_amendment is False
+
+    def test_amendment_flag_absent_defaults_false(self):
+        rows = [
+            _make_csv_row(ELEMENT_MAP['company_name'], 'FilingDateInstant', 'テスト'),
+        ]
+        report = parse_internal_control(_make_doc(rows=rows))
+        assert report.is_amendment is False
+
+
+# ---------------------------------------------------------------------------
+# Dataclass and repr
+# ---------------------------------------------------------------------------
+
+class TestInternalControlReportDataclass:
+    def test_defaults_all_none(self):
+        report = InternalControlReport(doc_id='X', doc_type_code='235')
+        assert report.company_name is None
+        assert report.filing_date is None
+        assert report.representative is None
+        assert report.cfo is None
+        assert report.evaluation_result_text is None
+        assert report.is_amendment is False
+
+    def test_repr_normal(self):
+        report = InternalControlReport(
+            doc_id='X',
+            doc_type_code='235',
+            company_name='テスト株式会社',
+        )
+        r = repr(report)
+        assert 'InternalControlReport' in r
+        assert 'テスト' in r
+        assert 'AMENDED' not in r
+
+    def test_repr_amendment(self):
+        report = InternalControlReport(
+            doc_id='X',
+            doc_type_code='236',
+            company_name='テスト',
+            is_amendment=True,
+        )
+        assert 'AMENDED' in repr(report)
+
+    def test_repr_truncates_long_name(self):
+        report = InternalControlReport(
+            doc_id='X',
+            doc_type_code='235',
+            company_name='A' * 50,
+        )
+        assert '...' in repr(report)
+
+    def test_to_dict_excludes_raw_fields(self):
+        report = InternalControlReport(
+            doc_id='X',
+            doc_type_code='235',
+            company_name='テスト',
+            raw_fields={'k': 'v'},
+            unmapped_fields={'u': 'v'},
+        )
+        d = report.to_dict()
+        assert d['company_name'] == 'テスト'
+        assert 'raw_fields' not in d
+        assert 'unmapped_fields' not in d
+
+    def test_fields_list_contains_expected_keys(self):
+        report = InternalControlReport(doc_id='X', doc_type_code='235')
+        f = report.fields()
+        for key in ['company_name', 'filing_date', 'representative', 'cfo',
+                    'evaluation_result_text', 'is_amendment']:
+            assert key in f, f"Expected field '{key}' in fields()"
+
+
+# ---------------------------------------------------------------------------
+# ELEMENT_MAP sanity checks
+# ---------------------------------------------------------------------------
+
+class TestElementMap:
+    def test_required_keys_present(self):
+        required = [
+            'filer_name', 'filer_edinet_code', 'amendment_flag',
+            'company_name', 'filing_date', 'representative', 'cfo',
+            'evaluation_result_text',
+        ]
+        for key in required:
+            assert key in ELEMENT_MAP, f"Missing required ELEMENT_MAP key: {key}"
+
+    def test_all_values_are_namespaced(self):
+        for key, elem_id in ELEMENT_MAP.items():
+            assert ':' in elem_id, f"Element '{key}' missing namespace prefix: {elem_id}"
+
+    def test_dei_keys_use_jpdei_namespace(self):
+        for key in ('filer_name', 'filer_edinet_code', 'security_code', 'amendment_flag'):
+            assert ELEMENT_MAP[key].startswith('jpdei_cor:'), (
+                f"DEI key '{key}' should use jpdei_cor namespace"
+            )
+
+    def test_cover_page_keys_use_jpctl_namespace(self):
+        for key in ('company_name', 'filing_date', 'representative', 'cfo'):
+            assert ELEMENT_MAP[key].startswith('jpctl_cor:'), (
+                f"Cover page key '{key}' should use jpctl_cor namespace"
+            )

--- a/tests/test_issuance_parsers.py
+++ b/tests/test_issuance_parsers.py
@@ -1,0 +1,570 @@
+"""Tests for issuance family parsers (Doc types 060-110)."""
+import io
+import zipfile
+import pytest
+from datetime import date
+from unittest.mock import MagicMock
+
+from edinet_tools.parsers import parse
+from edinet_tools.parsers.generic import RawReport
+from edinet_tools.parsers.shelf_registration import (
+    ShelfRegistrationReport,
+    parse_shelf_registration,
+    ELEMENT_MAP as SHELF_ELEMENT_MAP,
+)
+from edinet_tools.parsers.issuance_notification import (
+    IssuanceNotificationReport,
+    parse_issuance_notification,
+)
+from edinet_tools.parsers.issuance_supplementary import (
+    IssuanceSupplementaryReport,
+    parse_issuance_supplementary,
+    ELEMENT_MAP as SUPP_ELEMENT_MAP,
+)
+from edinet_tools.parsers.issuance_withdrawal import (
+    IssuanceWithdrawalReport,
+    parse_issuance_withdrawal,
+)
+
+
+# --- Routing tests ---
+
+DOC_TYPES = ['060', '070', '080', '090', '100', '110']
+
+
+@pytest.mark.parametrize("code", DOC_TYPES)
+def test_issuance_type_does_not_fall_through(code):
+    """Issuance doc types must not fall through to RawReport."""
+    doc = MagicMock()
+    doc.doc_type_code = code
+    doc.doc_id = f"TEST_{code}"
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert not isinstance(result, RawReport), \
+            f"Doc type {code} fell through to RawReport instead of a typed parser"
+    except Exception:
+        pass  # Parser attempted but failed on mock data = correct routing
+
+
+def test_doc_080_routes_to_shelf_registration():
+    doc = MagicMock()
+    doc.doc_type_code = '080'
+    doc.doc_id = 'TEST_080'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, ShelfRegistrationReport)
+    except Exception:
+        pass
+
+
+def test_doc_090_routes_to_shelf_registration():
+    """Doc 090 (shelf registration amendment) routes to same parser as 080."""
+    doc = MagicMock()
+    doc.doc_type_code = '090'
+    doc.doc_id = 'TEST_090'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, ShelfRegistrationReport)
+    except Exception:
+        pass
+
+
+def test_doc_070_routes_to_shelf_registration():
+    """Doc 070 is also a shelf registration filing family."""
+    doc = MagicMock()
+    doc.doc_type_code = '070'
+    doc.doc_id = 'TEST_070'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, ShelfRegistrationReport)
+    except Exception:
+        pass
+
+
+def test_doc_060_routes_to_issuance_notification():
+    doc = MagicMock()
+    doc.doc_type_code = '060'
+    doc.doc_id = 'TEST_060'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, IssuanceNotificationReport)
+    except Exception:
+        pass
+
+
+def test_doc_100_routes_to_issuance_supplementary():
+    doc = MagicMock()
+    doc.doc_type_code = '100'
+    doc.doc_id = 'TEST_100'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, IssuanceSupplementaryReport)
+    except Exception:
+        pass
+
+
+def test_doc_110_routes_to_issuance_withdrawal():
+    doc = MagicMock()
+    doc.doc_type_code = '110'
+    doc.doc_id = 'TEST_110'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, IssuanceWithdrawalReport)
+    except Exception:
+        pass
+
+
+# --- ShelfRegistrationReport structure tests ---
+
+class TestShelfRegistrationReportStructure:
+    """Test ShelfRegistrationReport dataclass."""
+
+    def test_basic_fields(self):
+        from datetime import date
+        report = ShelfRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='080',
+            filer_name='テスト株式会社',
+            filer_edinet_code='E01234',
+            shelf_registration_number='第1号',
+            filing_date=date(2024, 4, 1),
+            is_amendment=False,
+        )
+        assert report.filer_name == 'テスト株式会社'
+        assert report.shelf_registration_number == '第1号'
+        assert report.is_amendment is False
+
+    def test_optional_fields_default_none(self):
+        report = ShelfRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='080',
+        )
+        assert report.filer_name is None
+        assert report.shelf_registration_number is None
+        assert report.planned_period is None
+        assert report.security_types is None
+        assert report.is_amendment is False
+
+    def test_amendment_flag(self):
+        report = ShelfRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='090',
+            is_amendment=True,
+        )
+        assert report.is_amendment is True
+        assert report.doc_type_code == '090'
+
+    def test_repr_normal(self):
+        report = ShelfRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='080',
+            filer_name='テスト株式会社',
+            shelf_registration_number='第1号',
+        )
+        r = repr(report)
+        assert 'テスト' in r
+        assert '第1号' in r
+        assert 'AMENDED' not in r
+
+    def test_repr_amendment(self):
+        report = ShelfRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='090',
+            is_amendment=True,
+        )
+        assert 'AMENDED' in repr(report)
+
+    def test_repr_truncates_long_names(self):
+        report = ShelfRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='080',
+            filer_name='A' * 50,
+        )
+        r = repr(report)
+        assert '...' in r
+
+    def test_to_dict_excludes_raw_fields(self):
+        report = ShelfRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='080',
+            filer_name='Test Corp',
+            raw_fields={'key': 'val'},
+        )
+        d = report.to_dict()
+        assert d['filer_name'] == 'Test Corp'
+        assert 'raw_fields' not in d
+
+
+# --- parse_shelf_registration with mock CSV data ---
+
+class TestParseShelfRegistration:
+    """Test parse_shelf_registration with mocked document data."""
+
+    def _make_csv_row(self, element_id, context_id, value):
+        return {
+            '要素ID': element_id,
+            'コンテキストID': context_id,
+            '値': value,
+        }
+
+    def _make_zip_with_rows(self, rows):
+        import io
+        import zipfile
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, 'w') as zf:
+            lines = []
+            for row in rows:
+                line = f"{row['要素ID']}\tlabel\t{row['コンテキストID']}\t0\t連結\t期間\tunit1\t円\t{row['値']}"
+                lines.append(line)
+            content = '\n'.join(lines)
+            zf.writestr('XBRL_TO_CSV/test.csv', content.encode('utf-16le'))
+        return zip_buffer.getvalue()
+
+    def _make_doc(self, doc_id='S100TEST', doc_type='080', rows=None):
+        doc = MagicMock()
+        doc.doc_id = doc_id
+        doc.doc_type_code = doc_type
+        doc.filer_name = ''
+        doc.filer_edinet_code = ''
+        if rows is not None:
+            doc.fetch.return_value = self._make_zip_with_rows(rows)
+        else:
+            doc.fetch.return_value = b''
+        return doc
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = self._make_doc(rows=None)
+        report = parse_shelf_registration(doc)
+        assert isinstance(report, ShelfRegistrationReport)
+        assert report.doc_id == 'S100TEST'
+        assert report.filer_name is None
+        assert report.source_files == []
+
+    def test_extracts_dei_fields(self):
+        rows = [
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['filer_name'],
+                'FilingDateInstant',
+                'テスト株式会社',
+            ),
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['filer_edinet_code'],
+                'FilingDateInstant',
+                'E01234',
+            ),
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['security_code'],
+                'FilingDateInstant',
+                '1234',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_shelf_registration(doc)
+        assert report.filer_name == 'テスト株式会社'
+        assert report.filer_edinet_code == 'E01234'
+        assert report.security_code == '1234'
+
+    def test_extracts_cover_page_fields(self):
+        rows = [
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['shelf_registration_number'],
+                'FilingDateInstant',
+                '第1号',
+            ),
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['planned_period'],
+                'FilingDateInstant',
+                '2024年4月1日から2026年3月31日まで',
+            ),
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['security_types'],
+                'FilingDateInstant',
+                '社債券',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_shelf_registration(doc)
+        assert report.shelf_registration_number == '第1号'
+        assert '2024' in report.planned_period
+        assert report.security_types == '社債券'
+
+    def test_extracts_filing_date(self):
+        from datetime import date
+        rows = [
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['filing_date'],
+                'FilingDateInstant',
+                '2024-04-01',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_shelf_registration(doc)
+        assert report.filing_date == date(2024, 4, 1)
+
+    def test_amendment_flag_true(self):
+        rows = [
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['amendment_flag'],
+                'FilingDateInstant',
+                'true',
+            ),
+        ]
+        doc = self._make_doc(doc_type='090', rows=rows)
+        report = parse_shelf_registration(doc)
+        assert report.is_amendment is True
+
+    def test_amendment_flag_false(self):
+        rows = [
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['amendment_flag'],
+                'FilingDateInstant',
+                'false',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_shelf_registration(doc)
+        assert report.is_amendment is False
+
+    def test_company_name_falls_back_to_filer_name(self):
+        """If cover page company_name missing, company_name falls back to DEI filer_name."""
+        rows = [
+            self._make_csv_row(
+                SHELF_ELEMENT_MAP['filer_name'],
+                'FilingDateInstant',
+                'DEI Filer Corp',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_shelf_registration(doc)
+        assert report.company_name == 'DEI Filer Corp'
+
+    def test_text_blocks_captured(self):
+        rows = [
+            self._make_csv_row(
+                'jpcrp_cor:UseOfNetProceedsTextBlock',
+                'FilingDateInstant',
+                '調達した資金の使途...',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_shelf_registration(doc)
+        assert 'UseOfNetProceedsTextBlock' in report.text_blocks
+
+
+# --- ELEMENT_MAP completeness tests ---
+
+class TestShelfElementMap:
+    """Test SHELF_ELEMENT_MAP completeness."""
+
+    def test_required_keys_present(self):
+        required = [
+            'filer_name', 'filer_edinet_code', 'filing_date',
+            'shelf_registration_number', 'planned_period', 'security_types',
+        ]
+        for key in required:
+            assert key in SHELF_ELEMENT_MAP, f"Missing required key: {key}"
+
+    def test_all_values_are_namespaced(self):
+        for key, elem_id in SHELF_ELEMENT_MAP.items():
+            assert ':' in elem_id, f"Element {key} missing namespace: {elem_id}"
+
+    def test_dei_elements_use_dei_namespace(self):
+        dei_keys = ['filer_name', 'filer_edinet_code', 'security_code', 'amendment_flag']
+        for key in dei_keys:
+            assert SHELF_ELEMENT_MAP[key].startswith('jpdei_cor:'), \
+                f"{key} should use jpdei_cor namespace"
+
+
+# --- Minimal parser smoke tests ---
+
+class TestMinimalIssuanceParsers:
+    """Smoke tests for minimal placeholder parsers."""
+
+    def _make_empty_doc(self, code):
+        doc = MagicMock()
+        doc.doc_id = f'TEST_{code}'
+        doc.doc_type_code = code
+        doc.fetch.return_value = b''
+        return doc
+
+    def test_parse_issuance_notification_empty(self):
+        doc = self._make_empty_doc('060')
+        report = parse_issuance_notification(doc)
+        assert isinstance(report, IssuanceNotificationReport)
+        assert report.doc_id == 'TEST_060'
+
+    def test_parse_issuance_supplementary_empty(self):
+        doc = self._make_empty_doc('100')
+        report = parse_issuance_supplementary(doc)
+        assert isinstance(report, IssuanceSupplementaryReport)
+        assert report.doc_id == 'TEST_100'
+
+    def test_parse_issuance_withdrawal_empty(self):
+        doc = self._make_empty_doc('110')
+        report = parse_issuance_withdrawal(doc)
+        assert isinstance(report, IssuanceWithdrawalReport)
+        assert report.doc_id == 'TEST_110'
+
+    def test_issuance_notification_repr(self):
+        report = IssuanceNotificationReport(doc_id='X', doc_type_code='060')
+        assert 'IssuanceNotificationReport' in repr(report)
+
+    def test_issuance_supplementary_repr(self):
+        report = IssuanceSupplementaryReport(doc_id='X', doc_type_code='100')
+        assert 'IssuanceSupplementaryReport' in repr(report)
+
+    def test_issuance_withdrawal_repr(self):
+        report = IssuanceWithdrawalReport(doc_id='X', doc_type_code='110')
+        assert 'IssuanceWithdrawalReport' in repr(report)
+
+
+# ---------------------------------------------------------------------------
+# IssuanceSupplementaryReport — field-level extraction tests (Doc 100)
+# ---------------------------------------------------------------------------
+
+def _make_supp_csv_row(element_id: str, context_id: str, value: str) -> str:
+    """Return one tab-separated line in EDINET CSV format (9 columns)."""
+    return f"{element_id}\tlabel\t{context_id}\t0\t連結\t期間\t\t\t{value}"
+
+
+def _make_supp_zip(rows: list[str]) -> bytes:
+    content = '\n'.join(rows)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('XBRL_TO_CSV/test.csv', content.encode('utf-16le'))
+    return buf.getvalue()
+
+
+def _make_supp_doc(doc_id: str = 'S100TEST', doc_type: str = '100', rows: list[str] | None = None):
+    doc = MagicMock()
+    doc.doc_id = doc_id
+    doc.doc_type_code = doc_type
+    doc.filer_name = ''
+    doc.filer_edinet_code = ''
+    doc.fetch.return_value = _make_supp_zip(rows) if rows is not None else b''
+    return doc
+
+
+class TestParseIssuanceSupplementary:
+    """Field-level extraction tests for IssuanceSupplementaryReport (Doc 100)."""
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_supp_doc(rows=None)
+        report = parse_issuance_supplementary(doc)
+        assert isinstance(report, IssuanceSupplementaryReport)
+        assert report.doc_id == 'S100TEST'
+        assert report.company_name is None
+        assert report.source_files == []
+
+    def test_extracts_company_name(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['company_name'], 'FilingDateInstant', 'テスト株式会社'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.company_name == 'テスト株式会社'
+
+    def test_extracts_supplement_number(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['supplement_number'], 'FilingDateInstant', '第3号'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.supplement_number == '第3号'
+
+    def test_extracts_remaining_balance(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['remaining_balance'], 'FilingDateInstant', '500億円'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.remaining_balance == '500億円'
+
+    def test_extracts_filing_date(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['filing_date'], 'FilingDateInstant', '2025-09-15'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.filing_date == date(2025, 9, 15)
+
+    def test_extracts_security_types(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['security_types'], 'FilingDateInstant', '普通社債券'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.security_types == '普通社債券'
+
+    def test_extracts_parent_shelf_reg_number(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['parent_shelf_reg_number'], 'FilingDateInstant', '第1号'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.parent_shelf_reg_number == '第1号'
+
+    def test_amendment_flag_true(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['amendment_flag'], 'FilingDateInstant', 'true'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.is_amendment is True
+
+    def test_amendment_flag_false(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['amendment_flag'], 'FilingDateInstant', 'false'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.is_amendment is False
+
+    def test_company_name_falls_back_to_filer_name(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['filer_name'], 'FilingDateInstant', 'フォールバック会社'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.company_name == 'フォールバック会社'
+
+    def test_multiple_fields_extracted_together(self):
+        rows = [
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['company_name'], 'FilingDateInstant', 'ABCホールディングス株式会社'),
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['supplement_number'], 'FilingDateInstant', '第2号'),
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['remaining_balance'], 'FilingDateInstant', '300億円'),
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['filing_date'], 'FilingDateInstant', '2025-03-01'),
+            _make_supp_csv_row(SUPP_ELEMENT_MAP['filer_edinet_code'], 'FilingDateInstant', 'E05678'),
+        ]
+        report = parse_issuance_supplementary(_make_supp_doc(rows=rows))
+        assert report.company_name == 'ABCホールディングス株式会社'
+        assert report.supplement_number == '第2号'
+        assert report.remaining_balance == '300億円'
+        assert report.filing_date == date(2025, 3, 1)
+        assert report.filer_edinet_code == 'E05678'
+
+    def test_repr_shows_supplement_number(self):
+        report = IssuanceSupplementaryReport(
+            doc_id='X',
+            doc_type_code='100',
+            company_name='テスト会社',
+            supplement_number='第1号',
+        )
+        r = repr(report)
+        assert 'テスト' in r
+        assert '第1号' in r
+
+
+class TestIssuanceSupplementaryElementMap:
+    """Sanity-check the SUPP_ELEMENT_MAP."""
+
+    def test_required_keys_present(self):
+        required = [
+            'filer_name', 'filer_edinet_code', 'filing_date',
+            'company_name', 'supplement_number', 'remaining_balance',
+        ]
+        for key in required:
+            assert key in SUPP_ELEMENT_MAP, f"Missing ELEMENT_MAP key: {key}"
+
+    def test_all_values_are_namespaced(self):
+        for key, elem_id in SUPP_ELEMENT_MAP.items():
+            assert ':' in elem_id, f"Element '{key}' missing namespace: {elem_id}"

--- a/tests/test_new_parsers.py
+++ b/tests/test_new_parsers.py
@@ -1,0 +1,237 @@
+"""
+Tests for the three new parser families:
+  - ConfirmationReport (Doc 135/136)
+  - ParentCompanyReport (Doc 200/210)
+  - LargeHoldingChangeReport (Doc 370/380)
+
+Covers routing (no fallthrough to RawReport), empty-document behaviour,
+dataclass defaults, repr, and supported_doc_types() count.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from edinet_tools.parsers import parse, supported_doc_types
+from edinet_tools.parsers.generic import RawReport
+from edinet_tools.parsers.confirmation import (
+    ConfirmationReport,
+    parse_confirmation,
+)
+from edinet_tools.parsers.parent_company import (
+    ParentCompanyReport,
+    parse_parent_company,
+)
+from edinet_tools.parsers.large_holding_change import (
+    LargeHoldingChangeReport,
+    parse_large_holding_change,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_doc(code: str) -> MagicMock:
+    doc = MagicMock()
+    doc.doc_type_code = code
+    doc.doc_id = f'TEST_{code}'
+    doc.filer_edinet_code = ''
+    doc.fetch.return_value = b''
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Routing — no fallthrough to RawReport
+# ---------------------------------------------------------------------------
+
+NEW_DOC_TYPES = ['135', '136', '200', '210', '370', '380']
+
+
+@pytest.mark.parametrize("code", NEW_DOC_TYPES)
+def test_new_doc_type_does_not_fall_through_to_raw(code):
+    """All 6 new doc type codes must route to a typed parser, not RawReport."""
+    doc = _make_doc(code)
+    try:
+        result = parse(doc)
+        assert not isinstance(result, RawReport), \
+            f"Doc type {code} fell through to RawReport instead of a typed parser"
+    except Exception:
+        pass  # Parser attempted but failed on empty mock data = correct routing
+
+
+def test_doc_135_routes_to_confirmation():
+    doc = _make_doc('135')
+    result = parse(doc)
+    assert isinstance(result, ConfirmationReport)
+
+
+def test_doc_136_routes_to_confirmation():
+    doc = _make_doc('136')
+    result = parse(doc)
+    assert isinstance(result, ConfirmationReport)
+
+
+def test_doc_200_routes_to_parent_company():
+    doc = _make_doc('200')
+    result = parse(doc)
+    assert isinstance(result, ParentCompanyReport)
+
+
+def test_doc_210_routes_to_parent_company():
+    doc = _make_doc('210')
+    result = parse(doc)
+    assert isinstance(result, ParentCompanyReport)
+
+
+def test_doc_370_routes_to_large_holding_change():
+    doc = _make_doc('370')
+    result = parse(doc)
+    assert isinstance(result, LargeHoldingChangeReport)
+
+
+def test_doc_380_routes_to_large_holding_change():
+    doc = _make_doc('380')
+    result = parse(doc)
+    assert isinstance(result, LargeHoldingChangeReport)
+
+
+# ---------------------------------------------------------------------------
+# Empty-document behaviour
+# ---------------------------------------------------------------------------
+
+class TestEmptyDocuments:
+    def test_confirmation_empty(self):
+        doc = _make_doc('135')
+        report = parse_confirmation(doc)
+        assert isinstance(report, ConfirmationReport)
+        assert report.doc_id == 'TEST_135'
+        assert report.filer_name is None
+        assert report.is_amendment is False
+        assert report.source_files == []
+
+    def test_confirmation_amendment_empty(self):
+        doc = _make_doc('136')
+        report = parse_confirmation(doc)
+        assert isinstance(report, ConfirmationReport)
+        assert report.doc_id == 'TEST_136'
+
+    def test_parent_company_empty(self):
+        doc = _make_doc('200')
+        report = parse_parent_company(doc)
+        assert isinstance(report, ParentCompanyReport)
+        assert report.doc_id == 'TEST_200'
+        assert report.filer_name is None
+        assert report.is_amendment is False
+        assert report.source_files == []
+
+    def test_parent_company_amendment_empty(self):
+        doc = _make_doc('210')
+        report = parse_parent_company(doc)
+        assert isinstance(report, ParentCompanyReport)
+        assert report.doc_id == 'TEST_210'
+
+    def test_large_holding_change_empty(self):
+        doc = _make_doc('370')
+        report = parse_large_holding_change(doc)
+        assert isinstance(report, LargeHoldingChangeReport)
+        assert report.doc_id == 'TEST_370'
+        assert report.filer_name is None
+        assert report.is_amendment is False
+        assert report.source_files == []
+
+    def test_large_holding_change_amendment_empty(self):
+        doc = _make_doc('380')
+        report = parse_large_holding_change(doc)
+        assert isinstance(report, LargeHoldingChangeReport)
+        assert report.doc_id == 'TEST_380'
+
+
+# ---------------------------------------------------------------------------
+# Dataclass defaults
+# ---------------------------------------------------------------------------
+
+class TestDataclassDefaults:
+    def test_confirmation_defaults(self):
+        r = ConfirmationReport(doc_id='X', doc_type_code='135')
+        assert r.filer_name is None
+        assert r.filer_name_en is None
+        assert r.filer_edinet_code is None
+        assert r.security_code is None
+        assert r.is_amendment is False
+
+    def test_parent_company_defaults(self):
+        r = ParentCompanyReport(doc_id='X', doc_type_code='200')
+        assert r.filer_name is None
+        assert r.filer_name_en is None
+        assert r.filer_edinet_code is None
+        assert r.security_code is None
+        assert r.is_amendment is False
+
+    def test_large_holding_change_defaults(self):
+        r = LargeHoldingChangeReport(doc_id='X', doc_type_code='370')
+        assert r.filer_name is None
+        assert r.filer_name_en is None
+        assert r.filer_edinet_code is None
+        assert r.security_code is None
+        assert r.is_amendment is False
+
+
+# ---------------------------------------------------------------------------
+# repr
+# ---------------------------------------------------------------------------
+
+class TestRepr:
+    def test_confirmation_repr_unknown(self):
+        r = ConfirmationReport(doc_id='X', doc_type_code='135')
+        assert 'ConfirmationReport' in repr(r)
+        assert 'Unknown' in repr(r)
+
+    def test_confirmation_repr_with_name(self):
+        r = ConfirmationReport(doc_id='X', doc_type_code='135', filer_name='テスト株式会社')
+        assert 'テスト' in repr(r)
+        assert 'AMENDED' not in repr(r)
+
+    def test_confirmation_repr_amendment(self):
+        r = ConfirmationReport(doc_id='X', doc_type_code='136', is_amendment=True)
+        assert 'AMENDED' in repr(r)
+
+    def test_confirmation_repr_truncates_long_name(self):
+        r = ConfirmationReport(doc_id='X', doc_type_code='135', filer_name='A' * 50)
+        assert '...' in repr(r)
+
+    def test_parent_company_repr_unknown(self):
+        r = ParentCompanyReport(doc_id='X', doc_type_code='200')
+        assert 'ParentCompanyReport' in repr(r)
+        assert 'Unknown' in repr(r)
+
+    def test_parent_company_repr_amendment(self):
+        r = ParentCompanyReport(doc_id='X', doc_type_code='210', is_amendment=True)
+        assert 'AMENDED' in repr(r)
+
+    def test_large_holding_change_repr_unknown(self):
+        r = LargeHoldingChangeReport(doc_id='X', doc_type_code='370')
+        assert 'LargeHoldingChangeReport' in repr(r)
+        assert 'Unknown' in repr(r)
+
+    def test_large_holding_change_repr_amendment(self):
+        r = LargeHoldingChangeReport(doc_id='X', doc_type_code='380', is_amendment=True)
+        assert 'AMENDED' in repr(r)
+
+
+# ---------------------------------------------------------------------------
+# supported_doc_types() count
+# ---------------------------------------------------------------------------
+
+def test_supported_doc_types_count():
+    """After adding 3 parsers (6 codes), total should be 42."""
+    codes = supported_doc_types()
+    assert len(codes) == 42, (
+        f"Expected 42 supported doc types, got {len(codes)}. "
+        f"Missing codes: {set(NEW_DOC_TYPES) - set(codes)}"
+    )
+
+
+def test_new_codes_in_supported_doc_types():
+    """All 6 new codes must appear in supported_doc_types()."""
+    codes = set(supported_doc_types())
+    for code in NEW_DOC_TYPES:
+        assert code in codes, f"Doc type {code} missing from supported_doc_types()"

--- a/tests/test_registration_parsers.py
+++ b/tests/test_registration_parsers.py
@@ -1,0 +1,695 @@
+"""Tests for securities registration/notification family parsers (Doc types 010-050)."""
+import io
+import zipfile
+import pytest
+from datetime import date
+from unittest.mock import MagicMock
+
+from edinet_tools.parsers import parse
+from edinet_tools.parsers.generic import RawReport
+from edinet_tools.parsers.securities_notification import (
+    SecuritiesNotificationReport,
+    parse_securities_notification,
+)
+from edinet_tools.parsers.securities_registration import (
+    SecuritiesRegistrationReport,
+    parse_securities_registration,
+    ELEMENT_MAP as REG_ELEMENT_MAP,
+)
+from edinet_tools.parsers.securities_withdrawal import (
+    SecuritiesWithdrawalReport,
+    parse_securities_withdrawal,
+)
+
+
+# --- Routing tests ---
+
+DOC_TYPES = ['010', '020', '030', '040', '050']
+
+
+@pytest.mark.parametrize("code", DOC_TYPES)
+def test_registration_type_does_not_fall_through(code):
+    """Registration/notification doc types must not fall through to RawReport."""
+    doc = MagicMock()
+    doc.doc_type_code = code
+    doc.doc_id = f"TEST_{code}"
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert not isinstance(result, RawReport), \
+            f"Doc type {code} fell through to RawReport instead of a typed parser"
+    except Exception:
+        pass  # Parser attempted but failed on mock data = correct routing
+
+
+def test_doc_010_routes_to_securities_notification():
+    doc = MagicMock()
+    doc.doc_type_code = '010'
+    doc.doc_id = 'TEST_010'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, SecuritiesNotificationReport)
+    except Exception:
+        pass
+
+
+def test_doc_020_routes_to_securities_notification():
+    """Doc 020 (amendment) routes to same parser as 010."""
+    doc = MagicMock()
+    doc.doc_type_code = '020'
+    doc.doc_id = 'TEST_020'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, SecuritiesNotificationReport)
+    except Exception:
+        pass
+
+
+def test_doc_030_routes_to_securities_registration():
+    doc = MagicMock()
+    doc.doc_type_code = '030'
+    doc.doc_id = 'TEST_030'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, SecuritiesRegistrationReport)
+    except Exception:
+        pass
+
+
+def test_doc_040_routes_to_securities_registration():
+    """Doc 040 (amendment) routes to same parser as 030."""
+    doc = MagicMock()
+    doc.doc_type_code = '040'
+    doc.doc_id = 'TEST_040'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, SecuritiesRegistrationReport)
+    except Exception:
+        pass
+
+
+def test_doc_050_routes_to_securities_withdrawal():
+    doc = MagicMock()
+    doc.doc_type_code = '050'
+    doc.doc_id = 'TEST_050'
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert isinstance(result, SecuritiesWithdrawalReport)
+    except Exception:
+        pass
+
+
+# --- SecuritiesRegistrationReport structure tests ---
+
+class TestSecuritiesRegistrationReportStructure:
+    """Test SecuritiesRegistrationReport dataclass."""
+
+    def test_basic_fields(self):
+        from datetime import date
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='030',
+            filer_name='テスト投信会社',
+            filer_edinet_code='E01234',
+            fund_name='テストファンド',
+            filing_date=date(2024, 4, 1),
+            is_amendment=False,
+        )
+        assert report.filer_name == 'テスト投信会社'
+        assert report.fund_name == 'テストファンド'
+        assert report.is_amendment is False
+
+    def test_optional_fields_default_none(self):
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='030',
+        )
+        assert report.filer_name is None
+        assert report.fund_name is None
+        assert report.issuer_name is None
+        assert report.is_amendment is False
+
+    def test_amendment_flag(self):
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='040',
+            is_amendment=True,
+        )
+        assert report.is_amendment is True
+        assert report.doc_type_code == '040'
+
+    def test_repr_normal(self):
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='030',
+            fund_name='テストファンド',
+        )
+        r = repr(report)
+        assert 'テストファンド' in r
+        assert 'AMENDED' not in r
+
+    def test_repr_amendment(self):
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='040',
+            is_amendment=True,
+        )
+        assert 'AMENDED' in repr(report)
+
+    def test_repr_prefers_fund_name_over_filer_name(self):
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='030',
+            filer_name='管理会社',
+            fund_name='ファンド名称',
+        )
+        r = repr(report)
+        assert 'ファンド名称' in r
+
+    def test_repr_falls_back_to_filer_name(self):
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='030',
+            filer_name='管理会社',
+        )
+        r = repr(report)
+        assert '管理会社' in r
+
+    def test_repr_truncates_long_names(self):
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='030',
+            fund_name='A' * 50,
+        )
+        r = repr(report)
+        assert '...' in r
+
+    def test_to_dict_excludes_raw_fields(self):
+        report = SecuritiesRegistrationReport(
+            doc_id='S100TEST',
+            doc_type_code='030',
+            filer_name='Test Corp',
+            raw_fields={'key': 'val'},
+        )
+        d = report.to_dict()
+        assert d['filer_name'] == 'Test Corp'
+        assert 'raw_fields' not in d
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers for jpsps_cor field tests
+# ---------------------------------------------------------------------------
+
+def _make_reg_csv_row(element_id: str, context_id: str, value: str) -> str:
+    """Return one tab-separated line in EDINET CSV format (9 columns)."""
+    return f"{element_id}\tlabel\t{context_id}\t0\t連結\t期間\t\t\t{value}"
+
+
+def _make_reg_zip(rows: list[str]) -> bytes:
+    content = '\n'.join(rows)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('XBRL_TO_CSV/test.csv', content.encode('utf-16le'))
+    return buf.getvalue()
+
+
+def _make_reg_doc(doc_id: str = 'S030TEST', doc_type: str = '030', rows: list[str] | None = None):
+    doc = MagicMock()
+    doc.doc_id = doc_id
+    doc.doc_type_code = doc_type
+    doc.filer_name = ''
+    doc.filer_edinet_code = ''
+    doc.fetch.return_value = _make_reg_zip(rows) if rows is not None else b''
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# New jpsps_cor field-level extraction tests
+# ---------------------------------------------------------------------------
+
+class TestSecuritiesRegistrationCoverPageFields:
+    """Test the new cover page jpsps_cor fields: contact_person, telephone, place_of_filing."""
+
+    def test_extracts_contact_person(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['contact_person'], 'FilingDateInstant', '運用部　佐藤花子')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.contact_person == '運用部　佐藤花子'
+
+    def test_extracts_telephone_number(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['telephone_number'], 'FilingDateInstant', '03-5555-1234')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.telephone_number == '03-5555-1234'
+
+    def test_extracts_place_of_filing(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['place_of_filing'], 'FilingDateInstant', '関東財務局長')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.place_of_filing == '関東財務局長'
+
+    def test_extracts_amount_to_register(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['amount_to_register'], 'FilingDateInstant', '1口以上1口単位')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.amount_to_register == '1口以上1口単位'
+
+    def test_extracts_fund_name_for_registration(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['fund_name_for_registration'], 'FilingDateInstant', 'テスト日本株式ファンド')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.fund_name_for_registration == 'テスト日本株式ファンド'
+
+    def test_missing_cover_page_fields_are_none(self):
+        """No rows → all new cover page fields should be None."""
+        report = parse_securities_registration(_make_reg_doc(rows=[]))
+        assert report.contact_person is None
+        assert report.telephone_number is None
+        assert report.place_of_filing is None
+        assert report.amount_to_register is None
+        assert report.fund_name_for_registration is None
+
+
+class TestSecuritiesRegistrationFundIdentityFields:
+    """Test fund identity TextBlock fields: fund_purpose, fund_scheme, fund_history."""
+
+    def test_extracts_fund_purpose(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['fund_purpose'], 'FilingDateInstant', '国内株式に投資するファンドです。')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.fund_purpose == '国内株式に投資するファンドです。'
+
+    def test_extracts_fund_scheme(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['fund_scheme'], 'FilingDateInstant', '単位型・追加型：追加型')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.fund_scheme == '単位型・追加型：追加型'
+
+    def test_extracts_fund_history(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['fund_history'], 'FilingDateInstant', '2000年1月設定')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.fund_history == '2000年1月設定'
+
+    def test_fund_identity_in_text_blocks_dict(self):
+        """Fund identity TextBlocks are also captured in the text_blocks dict."""
+        rows = [
+            _make_reg_csv_row(REG_ELEMENT_MAP['fund_purpose'], 'FilingDateInstant', 'ファンドの目的'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['fund_scheme'], 'FilingDateInstant', 'ファンドの仕組み'),
+        ]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert 'PurposesAndBasicFeaturesOfFundTextBlock' in report.text_blocks
+        assert 'FundSchemeTextBlock' in report.text_blocks
+
+
+class TestSecuritiesRegistrationInvestmentPolicyFields:
+    """Test investment policy TextBlock fields."""
+
+    def test_extracts_investment_policy(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['investment_policy'], 'FilingDateInstant', '主として国内株式に投資します。')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.investment_policy == '主として国内株式に投資します。'
+
+    def test_extracts_investment_risks(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['investment_risks'], 'FilingDateInstant', '株価変動リスクがあります。')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.investment_risks == '株価変動リスクがあります。'
+
+    def test_extracts_eligible_investments(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['eligible_investments'], 'FilingDateInstant', '国内上場株式')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.eligible_investments == '国内上場株式'
+
+    def test_extracts_investment_restrictions(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['investment_restrictions'], 'FilingDateInstant', '同一銘柄10%以内')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.investment_restrictions == '同一銘柄10%以内'
+
+
+class TestSecuritiesRegistrationOperationsFields:
+    """Test operations TextBlock fields: fees, application, redemption, distribution."""
+
+    def test_extracts_management_fees(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['management_fees'], 'FilingDateInstant', '年率1.0%（税込）')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.management_fees == '年率1.0%（税込）'
+
+    def test_extracts_application_fee(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['application_fee'], 'FilingDateInstant', '3.3%以内')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.application_fee == '3.3%以内'
+
+    def test_extracts_application_period(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['application_period'], 'FilingDateInstant', '毎営業日')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.application_period == '毎営業日'
+
+    def test_extracts_application_unit(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['application_unit'], 'FilingDateInstant', '1口以上1口単位')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.application_unit == '1口以上1口単位'
+
+    def test_extracts_redemption_procedures(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['redemption_procedures'], 'FilingDateInstant', '翌営業日解約')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.redemption_procedures == '翌営業日解約'
+
+    def test_extracts_profit_distribution_policy(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['profit_distribution_policy'], 'FilingDateInstant', '毎月分配')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.profit_distribution_policy == '毎月分配'
+
+    def test_extracts_taxation(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['taxation'], 'FilingDateInstant', '普通分配金は課税対象')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.taxation == '普通分配金は課税対象'
+
+
+class TestSecuritiesRegistrationFinancialFields:
+    """Test financial information TextBlock fields."""
+
+    def test_extracts_financial_info(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['financial_info'], 'FilingDateInstant', '純資産総額：100億円')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.financial_info == '純資産総額：100億円'
+
+    def test_extracts_balance_sheet(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['balance_sheet'], 'FilingDateInstant', '資産合計：100億円')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.balance_sheet == '資産合計：100億円'
+
+    def test_extracts_income_statement(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['income_statement'], 'FilingDateInstant', '当期純利益：5億円')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.income_statement == '当期純利益：5億円'
+
+    def test_extracts_changes_in_net_assets(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['changes_in_net_assets'], 'FilingDateInstant', '期末純資産総額：100億円')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.changes_in_net_assets == '期末純資産総額：100億円'
+
+    def test_extracts_net_assets_calculation(self):
+        rows = [_make_reg_csv_row(REG_ELEMENT_MAP['net_assets_calculation'], 'FilingDateInstant', '1口当たり純資産額：10,000円')]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert report.net_assets_calculation == '1口当たり純資産額：10,000円'
+
+    def test_financial_blocks_in_text_blocks_dict(self):
+        """Financial TextBlocks also appear in the text_blocks dict."""
+        rows = [
+            _make_reg_csv_row(REG_ELEMENT_MAP['balance_sheet'], 'FilingDateInstant', '資産合計：50億円'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['income_statement'], 'FilingDateInstant', '利益：1億円'),
+        ]
+        report = parse_securities_registration(_make_reg_doc(rows=rows))
+        assert 'BalanceSheetTextBlock' in report.text_blocks
+        assert 'StatementOfIncomeAndRetainedEarningsTextBlock' in report.text_blocks
+
+
+class TestSecuritiesRegistrationFullIntegration:
+    """Integration test: extract all field groups from a single mock filing."""
+
+    def test_full_filing_extraction(self):
+        rows = [
+            # DEI
+            _make_reg_csv_row(REG_ELEMENT_MAP['filer_name'], 'FilingDateInstant', '大和アセットマネジメント株式会社'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['filer_edinet_code'], 'FilingDateInstant', 'E05678'),
+            # Cover page
+            _make_reg_csv_row(REG_ELEMENT_MAP['filing_date'], 'FilingDateInstant', '2025-06-15'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['issuer_name'], 'FilingDateInstant', '大和アセットマネジメント株式会社'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['contact_person'], 'FilingDateInstant', '運用部　田中'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['telephone_number'], 'FilingDateInstant', '03-5555-9999'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['place_of_filing'], 'FilingDateInstant', '関東財務局長'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['fund_name_for_registration'], 'FilingDateInstant', 'ダイワ日本株式オープン'),
+            # Fund identity
+            _make_reg_csv_row(REG_ELEMENT_MAP['fund_name'], 'FilingDateInstant', 'ダイワ日本株式オープン'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['fund_purpose'], 'FilingDateInstant', '国内株式に投資するファンド'),
+            # Investment policy
+            _make_reg_csv_row(REG_ELEMENT_MAP['investment_policy'], 'FilingDateInstant', '国内株式への分散投資'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['investment_risks'], 'FilingDateInstant', '価格変動リスク'),
+            # Operations
+            _make_reg_csv_row(REG_ELEMENT_MAP['management_fees'], 'FilingDateInstant', '年率0.99%（税込）'),
+            _make_reg_csv_row(REG_ELEMENT_MAP['redemption_procedures'], 'FilingDateInstant', '翌営業日解約可能'),
+            # Financial
+            _make_reg_csv_row(REG_ELEMENT_MAP['balance_sheet'], 'FilingDateInstant', '純資産：200億円'),
+        ]
+        report = parse_securities_registration(_make_reg_doc(doc_id='S030FULL', rows=rows))
+
+        assert report.doc_id == 'S030FULL'
+        assert report.filer_name == '大和アセットマネジメント株式会社'
+        assert report.filer_edinet_code == 'E05678'
+        assert report.filing_date == date(2025, 6, 15)
+        assert report.issuer_name == '大和アセットマネジメント株式会社'
+        assert report.contact_person == '運用部　田中'
+        assert report.telephone_number == '03-5555-9999'
+        assert report.place_of_filing == '関東財務局長'
+        assert report.fund_name_for_registration == 'ダイワ日本株式オープン'
+        assert report.fund_name == 'ダイワ日本株式オープン'
+        assert report.fund_purpose == '国内株式に投資するファンド'
+        assert report.investment_policy == '国内株式への分散投資'
+        assert report.investment_risks == '価格変動リスク'
+        assert report.management_fees == '年率0.99%（税込）'
+        assert report.redemption_procedures == '翌営業日解約可能'
+        assert report.balance_sheet == '純資産：200億円'
+        assert report.is_amendment is False
+
+
+# --- parse_securities_registration with mock CSV data ---
+
+class TestParseSecuritiesRegistration:
+    """Test parse_securities_registration with mocked document data."""
+
+    def _make_csv_row(self, element_id, context_id, value):
+        return {
+            '要素ID': element_id,
+            'コンテキストID': context_id,
+            '値': value,
+        }
+
+    def _make_zip_with_rows(self, rows):
+        import io
+        import zipfile
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, 'w') as zf:
+            lines = []
+            for row in rows:
+                line = f"{row['要素ID']}\tlabel\t{row['コンテキストID']}\t0\t連結\t期間\tunit1\t円\t{row['値']}"
+                lines.append(line)
+            content = '\n'.join(lines)
+            zf.writestr('XBRL_TO_CSV/test.csv', content.encode('utf-16le'))
+        return zip_buffer.getvalue()
+
+    def _make_doc(self, doc_id='S100TEST', doc_type='030', rows=None):
+        doc = MagicMock()
+        doc.doc_id = doc_id
+        doc.doc_type_code = doc_type
+        doc.filer_name = ''
+        doc.filer_edinet_code = ''
+        if rows is not None:
+            doc.fetch.return_value = self._make_zip_with_rows(rows)
+        else:
+            doc.fetch.return_value = b''
+        return doc
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = self._make_doc(rows=None)
+        report = parse_securities_registration(doc)
+        assert isinstance(report, SecuritiesRegistrationReport)
+        assert report.doc_id == 'S100TEST'
+        assert report.filer_name is None
+        assert report.source_files == []
+
+    def test_extracts_dei_fields(self):
+        rows = [
+            self._make_csv_row(
+                REG_ELEMENT_MAP['filer_name'],
+                'FilingDateInstant',
+                'テスト資産管理株式会社',
+            ),
+            self._make_csv_row(
+                REG_ELEMENT_MAP['filer_edinet_code'],
+                'FilingDateInstant',
+                'E09876',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_securities_registration(doc)
+        assert report.filer_name == 'テスト資産管理株式会社'
+        assert report.filer_edinet_code == 'E09876'
+
+    def test_extracts_fund_name(self):
+        rows = [
+            self._make_csv_row(
+                REG_ELEMENT_MAP['fund_name'],
+                'FilingDateInstant',
+                'テスト日本株式ファンド',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_securities_registration(doc)
+        assert report.fund_name == 'テスト日本株式ファンド'
+
+    def test_extracts_filing_date(self):
+        from datetime import date
+        rows = [
+            self._make_csv_row(
+                REG_ELEMENT_MAP['filing_date'],
+                'FilingDateInstant',
+                '2024-06-15',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_securities_registration(doc)
+        assert report.filing_date == date(2024, 6, 15)
+
+    def test_amendment_flag_true(self):
+        rows = [
+            self._make_csv_row(
+                REG_ELEMENT_MAP['amendment_flag'],
+                'FilingDateInstant',
+                'true',
+            ),
+        ]
+        doc = self._make_doc(doc_type='040', rows=rows)
+        report = parse_securities_registration(doc)
+        assert report.is_amendment is True
+
+    def test_issuer_name_falls_back_to_filer_name(self):
+        """If jpsps_cor issuer_name missing, falls back to DEI filer_name."""
+        rows = [
+            self._make_csv_row(
+                REG_ELEMENT_MAP['filer_name'],
+                'FilingDateInstant',
+                'DEI Filer Corp',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_securities_registration(doc)
+        assert report.issuer_name == 'DEI Filer Corp'
+
+    def test_text_blocks_captured(self):
+        rows = [
+            self._make_csv_row(
+                'jpsps_cor:FundNameTextBlock',
+                'FilingDateInstant',
+                'ファンド名テキスト',
+            ),
+        ]
+        doc = self._make_doc(rows=rows)
+        report = parse_securities_registration(doc)
+        assert 'FundNameTextBlock' in report.text_blocks
+
+
+# --- ELEMENT_MAP completeness tests ---
+
+class TestRegistrationElementMap:
+    """Test REG_ELEMENT_MAP completeness."""
+
+    def test_required_keys_present(self):
+        required = [
+            # Core identity
+            'filer_name', 'filer_edinet_code', 'filing_date',
+            'fund_name', 'issuer_name',
+            # New cover page fields
+            'contact_person', 'telephone_number', 'place_of_filing',
+            'amount_to_register', 'fund_name_for_registration',
+            # Fund identity
+            'fund_purpose', 'fund_scheme', 'fund_history',
+            # Investment policy
+            'investment_policy', 'investment_risks',
+            'eligible_investments', 'investment_restrictions',
+            # Operations
+            'management_fees', 'application_fee', 'application_period',
+            'application_unit', 'redemption_procedures',
+            'profit_distribution_policy', 'taxation',
+            # Financial
+            'financial_info', 'balance_sheet', 'income_statement',
+            'changes_in_net_assets', 'net_assets_calculation',
+        ]
+        for key in required:
+            assert key in REG_ELEMENT_MAP, f"Missing required key: {key}"
+
+    def test_all_values_are_namespaced(self):
+        for key, elem_id in REG_ELEMENT_MAP.items():
+            assert ':' in elem_id, f"Element {key} missing namespace: {elem_id}"
+
+    def test_dei_elements_use_dei_namespace(self):
+        dei_keys = ['filer_name', 'filer_edinet_code', 'security_code', 'amendment_flag']
+        for key in dei_keys:
+            assert REG_ELEMENT_MAP[key].startswith('jpdei_cor:'), \
+                f"{key} should use jpdei_cor namespace"
+
+    def test_fund_elements_use_jpsps_namespace(self):
+        jpsps_keys = [
+            'fund_name', 'issuer_name', 'filing_date',
+            'contact_person', 'telephone_number', 'place_of_filing',
+            'fund_purpose', 'fund_scheme', 'fund_history',
+            'investment_policy', 'investment_risks',
+            'management_fees', 'balance_sheet',
+        ]
+        for key in jpsps_keys:
+            assert REG_ELEMENT_MAP[key].startswith('jpsps_cor:'), \
+                f"{key} should use jpsps_cor namespace"
+
+    def test_text_block_fields_have_textblock_in_element_id(self):
+        """All TextBlock-sourced fields should map to elements with 'TextBlock' in the name."""
+        text_block_keys = [
+            'fund_name', 'fund_purpose', 'fund_scheme', 'fund_history',
+            'investment_policy', 'investment_risks', 'eligible_investments',
+            'investment_restrictions', 'management_fees', 'application_fee',
+            'application_period', 'application_unit', 'redemption_procedures',
+            'profit_distribution_policy', 'taxation',
+            'financial_info', 'balance_sheet', 'income_statement',
+            'changes_in_net_assets', 'net_assets_calculation',
+            'amount_to_register', 'fund_name_for_registration',
+        ]
+        for key in text_block_keys:
+            assert 'TextBlock' in REG_ELEMENT_MAP[key], \
+                f"{key} should map to a TextBlock element, got: {REG_ELEMENT_MAP[key]}"
+
+
+# --- Minimal parser smoke tests ---
+
+class TestMinimalRegistrationParsers:
+    """Smoke tests for minimal placeholder parsers."""
+
+    def _make_empty_doc(self, code):
+        doc = MagicMock()
+        doc.doc_id = f'TEST_{code}'
+        doc.doc_type_code = code
+        doc.fetch.return_value = b''
+        return doc
+
+    def test_parse_securities_notification_empty(self):
+        doc = self._make_empty_doc('010')
+        report = parse_securities_notification(doc)
+        assert isinstance(report, SecuritiesNotificationReport)
+        assert report.doc_id == 'TEST_010'
+
+    def test_parse_securities_withdrawal_empty(self):
+        doc = self._make_empty_doc('050')
+        report = parse_securities_withdrawal(doc)
+        assert isinstance(report, SecuritiesWithdrawalReport)
+        assert report.doc_id == 'TEST_050'
+
+    def test_securities_notification_repr_normal(self):
+        report = SecuritiesNotificationReport(
+            doc_id='X', doc_type_code='010', filer_name='テスト会社'
+        )
+        r = repr(report)
+        assert 'SecuritiesNotificationReport' in r
+        assert 'テスト会社' in r
+        assert 'AMENDED' not in r
+
+    def test_securities_notification_repr_amendment(self):
+        report = SecuritiesNotificationReport(
+            doc_id='X', doc_type_code='020', is_amendment=True
+        )
+        assert 'AMENDED' in repr(report)
+
+    def test_securities_withdrawal_repr(self):
+        report = SecuritiesWithdrawalReport(doc_id='X', doc_type_code='050')
+        assert 'SecuritiesWithdrawalReport' in repr(report)
+
+    def test_all_minimal_parsers_have_is_amendment_field(self):
+        """All parsers expose is_amendment consistently."""
+        report_n = SecuritiesNotificationReport(doc_id='X', doc_type_code='010')
+        report_w = SecuritiesWithdrawalReport(doc_id='X', doc_type_code='050')
+        assert report_n.is_amendment is False
+        assert report_w.is_amendment is False

--- a/tests/test_tender_offer_family.py
+++ b/tests/test_tender_offer_family.py
@@ -1,0 +1,594 @@
+"""
+Tests for the tender offer family parsers (Doc types 260-340).
+
+Covers routing, basic dataclass structure, and parse function behaviour
+for all five new parser modules:
+  - TenderOfferWithdrawalReport  (260)
+  - TenderOfferResultReport      (270, 280)
+  - OpinionReport                (290, 300)
+  - QuestionResponseReport       (310, 320)
+  - ExemptionApplicationReport   (330, 340)
+"""
+import io
+import zipfile
+import pytest
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock, Mock
+from edinet_tools.parsers import parse
+from edinet_tools.parsers.generic import RawReport
+from edinet_tools.parsers.tender_offer_withdrawal import (
+    TenderOfferWithdrawalReport,
+    parse_tender_offer_withdrawal,
+    ELEMENT_MAP as WITHDRAWAL_MAP,
+)
+from edinet_tools.parsers.tender_offer_report import (
+    TenderOfferResultReport,
+    parse_tender_offer_report,
+    ELEMENT_MAP as REPORT_MAP,
+)
+from edinet_tools.parsers.opinion_report import (
+    OpinionReport,
+    parse_opinion_report,
+    ELEMENT_MAP as OPINION_MAP,
+)
+from edinet_tools.parsers.question_response import (
+    QuestionResponseReport,
+    parse_question_response,
+    ELEMENT_MAP as QUESTION_MAP,
+)
+from edinet_tools.parsers.exemption_application import (
+    ExemptionApplicationReport,
+    parse_exemption_application,
+    ELEMENT_MAP as EXEMPTION_MAP,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_doc(doc_type_code: str, doc_id: str = 'TEST_DOC') -> Mock:
+    doc = Mock()
+    doc.doc_id = doc_id
+    doc.doc_type_code = doc_type_code
+    doc.filer_name = ''
+    doc.filer_edinet_code = ''
+    doc.fetch.return_value = b''  # Empty ZIP → empty CSV list
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Routing tests — parse() must NOT fall through to RawReport
+# ---------------------------------------------------------------------------
+
+DOC_TYPES = ['260', '270', '280', '290', '300', '310', '320', '330', '340']
+
+
+@pytest.mark.parametrize("code", DOC_TYPES)
+def test_tender_offer_family_does_not_fall_through(code):
+    """parse() must route to a typed parser, never RawReport, for all new codes."""
+    doc = MagicMock()
+    doc.doc_type_code = code
+    doc.doc_id = f"TEST_{code}"
+    doc.fetch.return_value = None
+    try:
+        result = parse(doc)
+        assert not isinstance(result, RawReport), (
+            f"Doc type {code} fell through to RawReport — add it to the router"
+        )
+    except Exception:
+        pass  # Parser errored, but it was routed — that's acceptable
+
+
+@pytest.mark.parametrize("code", ['260'])
+def test_doc_260_routes_to_withdrawal(code):
+    doc = _make_mock_doc(code)
+    result = parse(doc)
+    assert isinstance(result, TenderOfferWithdrawalReport)
+
+
+@pytest.mark.parametrize("code", ['270', '280'])
+def test_doc_270_280_routes_to_result_report(code):
+    doc = _make_mock_doc(code)
+    result = parse(doc)
+    assert isinstance(result, TenderOfferResultReport)
+
+
+@pytest.mark.parametrize("code", ['290', '300'])
+def test_doc_290_300_routes_to_opinion(code):
+    doc = _make_mock_doc(code)
+    result = parse(doc)
+    assert isinstance(result, OpinionReport)
+
+
+@pytest.mark.parametrize("code", ['310', '320'])
+def test_doc_310_320_routes_to_question_response(code):
+    doc = _make_mock_doc(code)
+    result = parse(doc)
+    assert isinstance(result, QuestionResponseReport)
+
+
+@pytest.mark.parametrize("code", ['330', '340'])
+def test_doc_330_340_routes_to_exemption(code):
+    doc = _make_mock_doc(code)
+    result = parse(doc)
+    assert isinstance(result, ExemptionApplicationReport)
+
+
+# ---------------------------------------------------------------------------
+# Dataclass field tests
+# ---------------------------------------------------------------------------
+
+class TestTenderOfferWithdrawalReport:
+    def test_basic_fields(self):
+        report = TenderOfferWithdrawalReport(
+            doc_id='TEST',
+            doc_type_code='260',
+            filer_name='テスト株式会社',
+            filer_edinet_code='E12345',
+            security_code='1234',
+            is_amendment=False,
+        )
+        assert report.filer_name == 'テスト株式会社'
+        assert report.filer_edinet_code == 'E12345'
+        assert report.is_amendment is False
+
+    def test_defaults_to_none(self):
+        report = TenderOfferWithdrawalReport(doc_id='X', doc_type_code='260')
+        assert report.filer_name is None
+        assert report.security_code is None
+        assert report.is_amendment is False
+
+    def test_repr(self):
+        report = TenderOfferWithdrawalReport(
+            doc_id='X', doc_type_code='260', filer_name='テスト株式会社'
+        )
+        assert 'TenderOfferWithdrawalReport' in repr(report)
+        assert 'テスト' in repr(report)
+
+    def test_repr_truncates_long_name(self):
+        report = TenderOfferWithdrawalReport(
+            doc_id='X', doc_type_code='260', filer_name='A' * 50
+        )
+        assert '...' in repr(report)
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_mock_doc('260')
+        result = parse_tender_offer_withdrawal(doc)
+        assert isinstance(result, TenderOfferWithdrawalReport)
+        assert result.filer_name is None
+        assert result.source_files == []
+
+
+class TestTenderOfferResultReport:
+    def test_basic_fields(self):
+        from decimal import Decimal
+        from datetime import date
+        report = TenderOfferResultReport(
+            doc_id='TEST',
+            doc_type_code='270',
+            acquirer_name='買付者株式会社',
+            target_name='対象会社',
+            voting_rights_purchased=100000,
+            purchase_ratio=Decimal('0.51'),
+            holding_ratio_after=Decimal('0.51'),
+            is_amendment=False,
+        )
+        assert report.acquirer_name == '買付者株式会社'
+        assert report.target_name == '対象会社'
+        assert report.voting_rights_purchased == 100000
+        assert report.purchase_ratio == Decimal('0.51')
+        assert report.is_amendment is False
+
+    def test_amendment_flag(self):
+        report = TenderOfferResultReport(
+            doc_id='TEST', doc_type_code='280', is_amendment=True
+        )
+        assert report.is_amendment is True
+        assert 'AMENDED' in repr(report)
+
+    def test_defaults_to_none(self):
+        report = TenderOfferResultReport(doc_id='X', doc_type_code='270')
+        assert report.acquirer_name is None
+        assert report.target_name is None
+        assert report.voting_rights_purchased is None
+        assert report.purchase_ratio is None
+        assert report.is_amendment is False
+
+    def test_repr(self):
+        report = TenderOfferResultReport(
+            doc_id='X', doc_type_code='270',
+            acquirer_name='買付者', target_name='対象会社'
+        )
+        r = repr(report)
+        assert 'TenderOfferResultReport' in r
+        assert '買付者' in r
+        assert '対象会社' in r
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_mock_doc('270')
+        result = parse_tender_offer_report(doc)
+        assert isinstance(result, TenderOfferResultReport)
+        assert result.acquirer_name is None
+        assert result.source_files == []
+
+
+class TestOpinionReport:
+    def test_basic_fields(self):
+        report = OpinionReport(
+            doc_id='TEST',
+            doc_type_code='290',
+            filer_name='対象会社株式会社',
+            filer_edinet_code='E99999',
+            security_code='9999',
+            is_amendment=False,
+        )
+        assert report.filer_name == '対象会社株式会社'
+        assert report.filer_edinet_code == 'E99999'
+        assert report.is_amendment is False
+
+    def test_amendment(self):
+        report = OpinionReport(doc_id='X', doc_type_code='300', is_amendment=True)
+        assert report.is_amendment is True
+        assert 'AMENDED' in repr(report)
+
+    def test_repr(self):
+        report = OpinionReport(
+            doc_id='X', doc_type_code='290', filer_name='テスト会社'
+        )
+        assert 'OpinionReport' in repr(report)
+        assert 'テスト会社' in repr(report)
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_mock_doc('290')
+        result = parse_opinion_report(doc)
+        assert isinstance(result, OpinionReport)
+        assert result.filer_name is None
+
+
+class TestQuestionResponseReport:
+    def test_basic_fields(self):
+        report = QuestionResponseReport(
+            doc_id='TEST',
+            doc_type_code='310',
+            filer_name='回答会社',
+            filer_edinet_code='E11111',
+            is_amendment=False,
+        )
+        assert report.filer_name == '回答会社'
+        assert report.is_amendment is False
+
+    def test_amendment(self):
+        report = QuestionResponseReport(
+            doc_id='X', doc_type_code='320', is_amendment=True
+        )
+        assert report.is_amendment is True
+        assert 'AMENDED' in repr(report)
+
+    def test_repr(self):
+        report = QuestionResponseReport(
+            doc_id='X', doc_type_code='310', filer_name='テスト会社'
+        )
+        assert 'QuestionResponseReport' in repr(report)
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_mock_doc('310')
+        result = parse_question_response(doc)
+        assert isinstance(result, QuestionResponseReport)
+        assert result.filer_name is None
+
+
+class TestExemptionApplicationReport:
+    def test_basic_fields(self):
+        report = ExemptionApplicationReport(
+            doc_id='TEST',
+            doc_type_code='330',
+            filer_name='申請会社',
+            filer_edinet_code='E22222',
+            is_amendment=False,
+        )
+        assert report.filer_name == '申請会社'
+        assert report.is_amendment is False
+
+    def test_amendment(self):
+        report = ExemptionApplicationReport(
+            doc_id='X', doc_type_code='340', is_amendment=True
+        )
+        assert report.is_amendment is True
+        assert 'AMENDED' in repr(report)
+
+    def test_repr(self):
+        report = ExemptionApplicationReport(
+            doc_id='X', doc_type_code='330', filer_name='テスト会社'
+        )
+        assert 'ExemptionApplicationReport' in repr(report)
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_mock_doc('330')
+        result = parse_exemption_application(doc)
+        assert isinstance(result, ExemptionApplicationReport)
+        assert result.filer_name is None
+
+
+# ---------------------------------------------------------------------------
+# ELEMENT_MAP sanity checks
+# ---------------------------------------------------------------------------
+
+class TestElementMaps:
+    """All ELEMENT_MAPs must have DEI baseline and namespaced values."""
+
+    @pytest.mark.parametrize("element_map,label", [
+        (WITHDRAWAL_MAP, 'TenderOfferWithdrawal'),
+        (REPORT_MAP, 'TenderOfferResult'),
+        (OPINION_MAP, 'Opinion'),
+        (QUESTION_MAP, 'QuestionResponse'),
+        (EXEMPTION_MAP, 'ExemptionApplication'),
+    ])
+    def test_has_dei_baseline(self, element_map, label):
+        for key in ('filer_name', 'filer_edinet_code', 'amendment_flag'):
+            assert key in element_map, f"{label}: missing key '{key}'"
+
+    @pytest.mark.parametrize("element_map,label", [
+        (WITHDRAWAL_MAP, 'TenderOfferWithdrawal'),
+        (REPORT_MAP, 'TenderOfferResult'),
+        (OPINION_MAP, 'Opinion'),
+        (QUESTION_MAP, 'QuestionResponse'),
+        (EXEMPTION_MAP, 'ExemptionApplication'),
+    ])
+    def test_values_are_namespaced(self, element_map, label):
+        for key, elem_id in element_map.items():
+            assert ':' in elem_id, (
+                f"{label}: element '{key}' missing namespace prefix: {elem_id}"
+            )
+
+    @pytest.mark.parametrize("element_map,label", [
+        (WITHDRAWAL_MAP, 'TenderOfferWithdrawal'),
+        (OPINION_MAP, 'Opinion'),
+        (QUESTION_MAP, 'QuestionResponse'),
+        (EXEMPTION_MAP, 'ExemptionApplication'),
+    ])
+    def test_dei_keys_use_dei_namespace(self, element_map, label):
+        for key in ('filer_name', 'filer_edinet_code', 'security_code', 'amendment_flag'):
+            if key in element_map:
+                assert element_map[key].startswith('jpdei_cor:'), (
+                    f"{label}: '{key}' should use jpdei_cor namespace"
+                )
+
+
+# ---------------------------------------------------------------------------
+# to_dict and inherited base behaviour
+# ---------------------------------------------------------------------------
+
+class TestBaseInheritance:
+    def test_to_dict_excludes_raw_fields(self):
+        report = OpinionReport(
+            doc_id='X',
+            doc_type_code='290',
+            filer_name='テスト',
+            raw_fields={'k': 'v'},
+            unmapped_fields={'u': 'v'},
+        )
+        d = report.to_dict()
+        assert d['filer_name'] == 'テスト'
+        assert 'raw_fields' not in d
+        assert 'unmapped_fields' not in d
+
+    def test_fields_returns_list(self):
+        report = TenderOfferResultReport(doc_id='X', doc_type_code='270')
+        f = report.fields()
+        assert isinstance(f, list)
+        assert 'acquirer_name' in f
+        assert 'target_name' in f
+        assert 'voting_rights_purchased' in f
+
+
+# ---------------------------------------------------------------------------
+# Field-level extraction helpers (shared)
+# ---------------------------------------------------------------------------
+
+def _make_csv_row(element_id: str, context_id: str, value: str) -> str:
+    """Return one tab-separated CSV line in EDINET format (9 columns)."""
+    return f"{element_id}\tlabel\t{context_id}\t0\t連結\t期間\t\t\t{value}"
+
+
+def _make_zip(rows: list[str]) -> bytes:
+    content = '\n'.join(rows)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('XBRL_TO_CSV/test.csv', content.encode('utf-16le'))
+    return buf.getvalue()
+
+
+def _make_family_doc(doc_id: str = 'S100TEST', doc_type: str = '270', rows: list[str] | None = None):
+    doc = Mock()
+    doc.doc_id = doc_id
+    doc.doc_type_code = doc_type
+    doc.filer_name = ''
+    doc.filer_edinet_code = ''
+    doc.fetch.return_value = _make_zip(rows) if rows is not None else b''
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# TenderOfferResultReport (270/280) — field-level extraction tests
+# ---------------------------------------------------------------------------
+
+class TestParseTenderOfferResultReport:
+    """Prove ELEMENT_MAP extracts correctly from mock XBRL CSV for Doc 270/280."""
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_family_doc(doc_type='270', rows=None)
+        result = parse_tender_offer_report(doc)
+        assert isinstance(result, TenderOfferResultReport)
+        assert result.acquirer_name is None
+        assert result.source_files == []
+
+    def test_extracts_acquirer_name(self):
+        rows = [
+            _make_csv_row(REPORT_MAP['acquirer_name'], 'FilingDateInstant', 'KDDI株式会社'),
+        ]
+        report = parse_tender_offer_report(_make_family_doc(rows=rows))
+        assert report.acquirer_name == 'KDDI株式会社'
+
+    def test_acquirer_falls_back_to_dei_filer_name(self):
+        """If cover page acquirer_name absent, falls back to DEI filer_name."""
+        rows = [
+            _make_csv_row(REPORT_MAP['filer_name'], 'FilingDateInstant', 'フォールバック株式会社'),
+        ]
+        report = parse_tender_offer_report(_make_family_doc(rows=rows))
+        assert report.acquirer_name == 'フォールバック株式会社'
+
+    def test_extracts_holding_ratio_after(self):
+        rows = [
+            _make_csv_row(REPORT_MAP['holding_ratio_after'], 'FilingDateInstant', '0.9876'),
+        ]
+        report = parse_tender_offer_report(_make_family_doc(rows=rows))
+        assert report.holding_ratio_after == Decimal('0.9876')
+
+    def test_extracts_purchase_ratio(self):
+        rows = [
+            _make_csv_row(REPORT_MAP['purchase_ratio'], 'FilingDateInstant', '0.4784'),
+        ]
+        report = parse_tender_offer_report(_make_family_doc(rows=rows))
+        assert report.purchase_ratio == Decimal('0.4784')
+
+    def test_extracts_filing_date(self):
+        rows = [
+            _make_csv_row(REPORT_MAP['filing_date'], 'FilingDateInstant', '2024-05-20'),
+        ]
+        report = parse_tender_offer_report(_make_family_doc(rows=rows))
+        assert report.filing_date == date(2024, 5, 20)
+
+    def test_result_text_block_captured(self):
+        rows = [
+            _make_csv_row(REPORT_MAP['result_text'], 'FilingDateInstant', '公開買付けは成立しました。'),
+        ]
+        report = parse_tender_offer_report(_make_family_doc(rows=rows))
+        # The result_text field should be populated directly
+        assert report.result_text == '公開買付けは成立しました。'
+        # TextBlock elements are also captured in text_blocks dict
+        assert 'SuccessOrFailureOfTenderOfferTextBlock' in report.text_blocks
+
+    def test_amendment_flag_true(self):
+        rows = [
+            _make_csv_row(REPORT_MAP['amendment_flag'], 'FilingDateInstant', 'true'),
+        ]
+        doc = _make_family_doc(doc_type='280', rows=rows)
+        report = parse_tender_offer_report(doc)
+        assert report.is_amendment is True
+
+    def test_amendment_flag_false(self):
+        rows = [
+            _make_csv_row(REPORT_MAP['amendment_flag'], 'FilingDateInstant', 'false'),
+        ]
+        report = parse_tender_offer_report(_make_family_doc(rows=rows))
+        assert report.is_amendment is False
+
+    def test_none_ratios_when_missing(self):
+        doc = _make_family_doc(rows=[])
+        report = parse_tender_offer_report(doc)
+        assert report.holding_ratio_after is None
+        assert report.purchase_ratio is None
+        assert report.voting_rights_purchased is None
+
+    def test_multiple_fields_extracted_together(self):
+        rows = [
+            _make_csv_row(REPORT_MAP['acquirer_name'], 'FilingDateInstant', 'テスト買付者株式会社'),
+            _make_csv_row(REPORT_MAP['holding_ratio_after'], 'FilingDateInstant', '1.0000'),
+            _make_csv_row(REPORT_MAP['filing_date'], 'FilingDateInstant', '2024-06-01'),
+            _make_csv_row(REPORT_MAP['filer_edinet_code'], 'FilingDateInstant', 'E07777'),
+        ]
+        report = parse_tender_offer_report(_make_family_doc(rows=rows))
+        assert report.acquirer_name == 'テスト買付者株式会社'
+        assert report.holding_ratio_after == Decimal('1.0000')
+        assert report.filing_date == date(2024, 6, 1)
+        assert report.acquirer_edinet_code == 'E07777'
+
+
+# ---------------------------------------------------------------------------
+# OpinionReport (290/300) — field-level extraction tests
+# ---------------------------------------------------------------------------
+
+class TestParseOpinionReport:
+    """Prove ELEMENT_MAP extracts correctly from mock XBRL CSV for Doc 290/300."""
+
+    def test_empty_zip_returns_empty_report(self):
+        doc = _make_family_doc(doc_type='290', rows=None)
+        result = parse_opinion_report(doc)
+        assert isinstance(result, OpinionReport)
+        assert result.target_company_name is None
+        assert result.source_files == []
+
+    def test_extracts_target_company_name(self):
+        rows = [
+            _make_csv_row(OPINION_MAP['target_company_name'], 'FilingDateInstant', '株式会社ローソン'),
+        ]
+        report = parse_opinion_report(_make_family_doc(doc_type='290', rows=rows))
+        assert report.target_company_name == '株式会社ローソン'
+
+    def test_target_company_name_falls_back_to_dei_filer_name(self):
+        rows = [
+            _make_csv_row(OPINION_MAP['filer_name'], 'FilingDateInstant', 'フォールバック対象会社'),
+        ]
+        report = parse_opinion_report(_make_family_doc(doc_type='290', rows=rows))
+        assert report.target_company_name == 'フォールバック対象会社'
+
+    def test_opinion_text_block_captured(self):
+        rows = [
+            _make_csv_row(
+                OPINION_MAP['opinion_text'],
+                'FilingDateInstant',
+                '本公開買付けに賛同する意見を表明いたします。',
+            ),
+        ]
+        report = parse_opinion_report(_make_family_doc(doc_type='290', rows=rows))
+        assert report.opinion_text == '本公開買付けに賛同する意見を表明いたします。'
+        # TextBlock elements are also captured in text_blocks
+        assert 'OpinionAndBasisAndReasonOfOpinionRegardingSaidTenderOfferTextBlock' in report.text_blocks
+
+    def test_extracts_filing_date(self):
+        rows = [
+            _make_csv_row(OPINION_MAP['filing_date'], 'FilingDateInstant', '2024-04-10'),
+        ]
+        report = parse_opinion_report(_make_family_doc(doc_type='290', rows=rows))
+        assert report.filing_date == date(2024, 4, 10)
+
+    def test_extracts_filer_edinet_code(self):
+        rows = [
+            _make_csv_row(OPINION_MAP['filer_edinet_code'], 'FilingDateInstant', 'E08888'),
+        ]
+        report = parse_opinion_report(_make_family_doc(doc_type='290', rows=rows))
+        assert report.filer_edinet_code == 'E08888'
+
+    def test_amendment_flag_true(self):
+        rows = [
+            _make_csv_row(OPINION_MAP['amendment_flag'], 'FilingDateInstant', 'true'),
+        ]
+        doc = _make_family_doc(doc_type='300', rows=rows)
+        report = parse_opinion_report(doc)
+        assert report.is_amendment is True
+
+    def test_amendment_flag_false(self):
+        rows = [
+            _make_csv_row(OPINION_MAP['amendment_flag'], 'FilingDateInstant', 'false'),
+        ]
+        report = parse_opinion_report(_make_family_doc(doc_type='290', rows=rows))
+        assert report.is_amendment is False
+
+    def test_multiple_fields_extracted_together(self):
+        rows = [
+            _make_csv_row(OPINION_MAP['target_company_name'], 'FilingDateInstant', 'テスト対象会社'),
+            _make_csv_row(OPINION_MAP['filing_date'], 'FilingDateInstant', '2024-04-05'),
+            _make_csv_row(OPINION_MAP['filer_edinet_code'], 'FilingDateInstant', 'E09876'),
+            _make_csv_row(
+                OPINION_MAP['opinion_text'],
+                'FilingDateInstant',
+                '賛同の意見を表明いたします。',
+            ),
+        ]
+        report = parse_opinion_report(_make_family_doc(doc_type='290', rows=rows))
+        assert report.target_company_name == 'テスト対象会社'
+        assert report.filing_date == date(2024, 4, 5)
+        assert report.filer_edinet_code == 'E09876'
+        assert '賛同' in report.opinion_text


### PR DESCRIPTION
Typed parsers for all 42 EDINET document types (up from 9). Amendment support, complete doc type registry, fetch_document(type=)
   for PDF/HTML downloads, 603 tests.